### PR TITLE
refactor: use `tmux command-prompt -F` to pass variables, instead of using temp files 

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -24,23 +24,16 @@ PERF=$(get_tmux_option "@easymotion-perf" "false")
 CASE_SENSITIVE=$(get_tmux_option "@easymotion-case-sensitive" "false")
 SMARTSIGN=$(get_tmux_option "@easymotion-smartsign" "false")
 
-# Create temporary input file with reset character
-create_input_file() {
-    local tmp_file=$(mktemp -t tmux-easymotion_keystroke-XXXXXXX)
-    printf '\x03' > "$tmp_file"
-    echo "$tmp_file"
-}
-
-# Build environment variables string for neww -d
-build_env_vars() {
+# Build environment variables options string for neww -d
+build_env_var_opts() {
     local motion_type=$1
-    echo "TMUX_EASYMOTION_HINTS=\"$HINTS\" \
-TMUX_EASYMOTION_VERTICAL_BORDER=\"$VERTICAL_BORDER\" \
-TMUX_EASYMOTION_HORIZONTAL_BORDER=\"$HORIZONTAL_BORDER\" \
-TMUX_EASYMOTION_USE_CURSES=\"$USE_CURSES\" \
-TMUX_EASYMOTION_DEBUG=\"$DEBUG\" \
-TMUX_EASYMOTION_PERF=\"$PERF\" \
-TMUX_EASYMOTION_CASE_SENSITIVE=\"$CASE_SENSITIVE\" \
-TMUX_EASYMOTION_SMARTSIGN=\"$SMARTSIGN\" \
-TMUX_EASYMOTION_MOTION_TYPE=\"$motion_type\""
+    echo "-e TMUX_EASYMOTION_HINTS=\\\"$HINTS\\\" \
+-e TMUX_EASYMOTION_VERTICAL_BORDER=\\\"$VERTICAL_BORDER\\\" \
+-e TMUX_EASYMOTION_HORIZONTAL_BORDER=\\\"$HORIZONTAL_BORDER\\\" \
+-e TMUX_EASYMOTION_USE_CURSES=\\\"$USE_CURSES\\\" \
+-e TMUX_EASYMOTION_DEBUG=\\\"$DEBUG\\\" \
+-e TMUX_EASYMOTION_PERF=\\\"$PERF\\\" \
+-e TMUX_EASYMOTION_CASE_SENSITIVE=\\\"$CASE_SENSITIVE\\\" \
+-e TMUX_EASYMOTION_SMARTSIGN=\\\"$SMARTSIGN\\\" \
+-e TMUX_EASYMOTION_MOTION_TYPE=\\\"$motion_type\\\""
 }

--- a/easymotion.py
+++ b/easymotion.py
@@ -352,14 +352,14 @@ def get_current_window_id():
     return sh(cmd).strip()
 
 
-def getch(input_file=None, num_chars=1):
+def getch(input_str=None, num_chars=1):
     """Get character(s) from terminal or file
 
     Args:
-        input_file: Optional filename to read from. If None, read from stdin.
+        input_str: Optional string. If None, read from stdin.
         num_chars: Number of characters to read (default: 1)
     """
-    if input_file is None:
+    if input_str is None:
         # Read from stdin
         fd = sys.stdin.fileno()
         old_settings = termios.tcgetattr(fd)
@@ -369,16 +369,7 @@ def getch(input_file=None, num_chars=1):
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
     else:
-        # Read from file
-        try:
-            with open(input_file, 'r') as f:
-                ch = f.read(num_chars)
-        except FileNotFoundError:
-            logging.info("File not found")
-            exit(1)
-        except Exception as e:
-            logging.error(f"Error reading from file: {str(e)}")
-            exit(1)
+        ch = input_str[:num_chars]
     if ch == '\x03':
         logging.info("Operation cancelled by user")
         exit(1)

--- a/mode-s.sh
+++ b/mode-s.sh
@@ -6,10 +6,8 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Load common configuration and functions
 source "$CURRENT_DIR/common.sh"
 
-# Create temporary input file
-tmp_file=$(create_input_file)
+# Build environment variables
+ENV_VARS_OPTS=$(build_env_vars "s")
 
 # Prompt for single character
-ENV_VARS=$(build_env_vars "s")
-tmux command-prompt -1 -p 'Search for 1 character:' "run-shell \"printf %s\\\\n \\\"%1\\\" > $tmp_file\"; \
-    neww -d '$ENV_VARS $CURRENT_DIR/easymotion.py $tmp_file'"
+tmux command-prompt -1F -p 'Search for 1 character:' "new-window -d $ENV_VARS_OPTS $CURRENT_DIR/easymotion.py \"%%%\""

--- a/mode-s2.sh
+++ b/mode-s2.sh
@@ -6,18 +6,19 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Load common configuration and functions
 source "$CURRENT_DIR/common.sh"
 
-# Create temporary input file
-tmp_file=$(create_input_file)
-
 # Build environment variables
-ENV_VARS=$(build_env_vars "s2")
+ENV_VAR_OPTS=$(build_env_var_opts "s2")
 
 # First prompt: get first character
-tmux command-prompt -1 -p 'Search for 2 characters:' \
-    "run-shell \"printf '%1' > $tmp_file\"; \
-     set-option -g @_easymotion_tmp_char1 '%1'"
+tmux source - <<-EOF
+    command-prompt -1 -p 'Search for 2 characters:' {
+        set-option -g @_easymotion_tmp_char1 "%1"
+    }
+EOF
 
 # Second prompt: get second character and launch easymotion
-tmux command-prompt -1 -p 'Search for 2 characters: #{@_easymotion_tmp_char1}' \
-    "run-shell \"printf '%1' >> $tmp_file && echo >> $tmp_file\"; \
-     neww -d '$ENV_VARS $CURRENT_DIR/easymotion.py $tmp_file'"
+tmux source - <<-EOF
+    command-prompt -1 -p 'Search for 2 characters: #{@_easymotion_tmp_char1}' {
+        run-shell -C "new-window -d $ENV_VAR_OPTS $CURRENT_DIR/easymotion.py \"#{q:@_easymotion_tmp_char1}%%%\""
+    }
+EOF


### PR DESCRIPTION
Includes fixes for #15.