### PR TITLE
feat: add opt-in copy-mode direct key binding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Press `prefix` + `I` to install
 | `@easymotion-hints` | `asdghklqwertyuiopzxcvbnmfj;` | Characters used for hints |
 | `@easymotion-case-sensitive` | `false` | Case-sensitive search |
 | `@easymotion-smartsign` | `false` | Match shifted symbols (e.g., `1` matches `!`) |
+| `@easymotion-copy-mode-no-prefix` | `false` | Bind keys directly in copy mode (no prefix required) |
 | `@easymotion-vertical-border` | `│` | Vertical border character |
 | `@easymotion-horizontal-border` | `─` | Horizontal border character |
 | `@easymotion-use-curses` | `false` | Use curses instead of ANSI sequences |

--- a/easymotion.tmux
+++ b/easymotion.tmux
@@ -24,10 +24,12 @@ if [ -z "$S_KEY" ]; then
     S_KEY=$(get_tmux_option "@easymotion-key" "s")
 fi
 
+COPY_MODE=$(get_tmux_option "@easymotion-copy-mode" "copy-mode-vi")
+
 # Setup 1-char search binding
 if [ -n "$S_KEY" ]; then
     tmux bind "$S_KEY" run-shell "$CURRENT_DIR/mode-s.sh"
-    tmux bind -T copy-mode-vi "$S_KEY" run-shell "$CURRENT_DIR/mode-s.sh"
+    tmux bind -T "$COPY_MODE" "$S_KEY" run-shell "$CURRENT_DIR/mode-s.sh"
 fi
 
 # ============================================================================
@@ -36,5 +38,5 @@ fi
 S2_KEY=$(get_tmux_option "@easymotion-s2" "")
 if [ -n "$S2_KEY" ]; then
     tmux bind "$S2_KEY" run-shell "$CURRENT_DIR/mode-s2.sh"
-    tmux bind -T copy-mode-vi "$S2_KEY" run-shell "$CURRENT_DIR/mode-s2.sh"
+    tmux bind -T "$COPY_MODE" "$S2_KEY" run-shell "$CURRENT_DIR/mode-s2.sh"
 fi

--- a/easymotion.tmux
+++ b/easymotion.tmux
@@ -27,6 +27,7 @@ fi
 # Setup 1-char search binding
 if [ -n "$S_KEY" ]; then
     tmux bind "$S_KEY" run-shell "$CURRENT_DIR/mode-s.sh"
+    tmux bind -T copy-mode-vi "$S_KEY" run-shell "$CURRENT_DIR/mode-s.sh"
 fi
 
 # ============================================================================
@@ -35,4 +36,5 @@ fi
 S2_KEY=$(get_tmux_option "@easymotion-s2" "")
 if [ -n "$S2_KEY" ]; then
     tmux bind "$S2_KEY" run-shell "$CURRENT_DIR/mode-s2.sh"
+    tmux bind -T copy-mode-vi "$S2_KEY" run-shell "$CURRENT_DIR/mode-s2.sh"
 fi

--- a/easymotion.tmux
+++ b/easymotion.tmux
@@ -24,12 +24,22 @@ if [ -z "$S_KEY" ]; then
     S_KEY=$(get_tmux_option "@easymotion-key" "s")
 fi
 
-COPY_MODE=$(get_tmux_option "@easymotion-copy-mode" "copy-mode-vi")
+COPY_MODE_NO_PREFIX=$(get_tmux_option "@easymotion-copy-mode-no-prefix" "")
+if [ "$COPY_MODE_NO_PREFIX" = "true" ]; then
+    MODE_KEYS=$(tmux show-option -gqv mode-keys)
+    if [ "$MODE_KEYS" = "vi" ]; then
+        COPY_MODE_TABLE="copy-mode-vi"
+    else
+        COPY_MODE_TABLE="copy-mode"
+    fi
+fi
 
 # Setup 1-char search binding
 if [ -n "$S_KEY" ]; then
     tmux bind "$S_KEY" run-shell "$CURRENT_DIR/mode-s.sh"
-    tmux bind -T "$COPY_MODE" "$S_KEY" run-shell "$CURRENT_DIR/mode-s.sh"
+    if [ -n "$COPY_MODE_TABLE" ]; then
+        tmux bind -T "$COPY_MODE_TABLE" "$S_KEY" run-shell "$CURRENT_DIR/mode-s.sh"
+    fi
 fi
 
 # ============================================================================
@@ -38,5 +48,7 @@ fi
 S2_KEY=$(get_tmux_option "@easymotion-s2" "")
 if [ -n "$S2_KEY" ]; then
     tmux bind "$S2_KEY" run-shell "$CURRENT_DIR/mode-s2.sh"
-    tmux bind -T "$COPY_MODE" "$S2_KEY" run-shell "$CURRENT_DIR/mode-s2.sh"
+    if [ -n "$COPY_MODE_TABLE" ]; then
+        tmux bind -T "$COPY_MODE_TABLE" "$S2_KEY" run-shell "$CURRENT_DIR/mode-s2.sh"
+    fi
 fi


### PR DESCRIPTION
## Summary

- Add `@easymotion-copy-mode-no-prefix` option to bind easymotion keys directly in copy mode without requiring the prefix key
- Defaults to `false` (opt-in) to avoid overwriting existing `copy-mode-vi` bindings
- Automatically detects `mode-keys` setting to select `copy-mode-vi` or `copy-mode` key table

## Usage

```bash
set -g @easymotion-copy-mode-no-prefix 'true'
```

Closes #23