### PR TITLE
fix: handle tab rendering on tmux 3.6+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,10 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
 
+    - name: Install tmux on macOS
+      if: runner.os == 'macOS'
+      run: brew install tmux
+
     - name: Show tmux version
       run: tmux -V
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
 
+    - name: Show tmux version
+      run: tmux -V
+
     - name: Run tests
       run: |
         pytest test_easymotion.py -v --cache-clear

--- a/easymotion.py
+++ b/easymotion.py
@@ -4,6 +4,7 @@ import functools
 import itertools
 import logging
 import os
+import re
 import subprocess
 import sys
 import termios
@@ -13,6 +14,38 @@ import unicodedata
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
 from typing import Any, List, Optional
+
+
+def _detect_tmux_version() -> tuple:
+    """Detect installed tmux version as (major, minor).
+
+    Returns (0, 0) when detection fails or the version cannot be parsed
+    (e.g. ``tmux master``, ``tmux openbsd-6.6``). The fallback selects the
+    pre-3.6 fixed-width tab behaviour, which matches every released tmux
+    that shipped before position-aware tab rendering.
+    """
+    try:
+        result = subprocess.run(
+            ["tmux", "-V"], capture_output=True, text=True, check=True
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return (0, 0)
+
+    version_str = result.stdout.strip()
+    if "openbsd-" in version_str or "master" in version_str:
+        return (0, 0)
+
+    match = re.search(r"(?:next-)?(\d+)\.(\d+)", version_str)
+    if match:
+        return (int(match.group(1)), int(match.group(2)))
+    return (0, 0)
+
+
+TMUX_VERSION = _detect_tmux_version()
+# tmux 3.6 changed tab rendering to be position-aware (terminal-correct),
+# matching the tab-stop behaviour expected by terminals. Older tmux
+# rendered tabs as a fixed 8-column glyph regardless of column.
+_TMUX_HAS_POSITION_AWARE_TABS = TMUX_VERSION >= (3, 6)
 
 
 @functools.lru_cache(maxsize=1)
@@ -242,24 +275,48 @@ def perf_timer(func_name=None):
     return decorator
 
 
+def calculate_tab_width(position: int, tab_size: int = 8) -> int:
+    """Visual columns a tab consumes when starting at ``position``."""
+    return tab_size - (position % tab_size)
+
+
 @functools.lru_cache(maxsize=1024)
-def get_char_width(char: str) -> int:
-    """Get visual width of a single character with caching"""
+def _char_width_no_tab(char: str) -> int:
     return 2 if unicodedata.east_asian_width(char) in "WF" else 1
+
+
+def get_char_width(char: str, position: int = 0) -> int:
+    """Get visual width of a single character.
+
+    ``position`` is only consulted for tab characters; for all other
+    characters the result is cached and independent of column. Tab width
+    depends on the running tmux version: 3.6+ renders tabs at the next
+    multiple of 8 (terminal-correct), older tmux always renders tabs as
+    8 columns. Falling back to the pre-3.6 behaviour when the version
+    cannot be detected keeps existing setups working.
+    """
+    if char == "\t":
+        if _TMUX_HAS_POSITION_AWARE_TABS:
+            return calculate_tab_width(position)
+        return 8
+    return _char_width_no_tab(char)
 
 
 @functools.lru_cache(maxsize=1024)
 def get_string_width(s: str) -> int:
-    """Calculate visual width of string, accounting for double-width characters"""
-    return sum(map(get_char_width, s))
+    """Visual width of a string, accounting for wide characters and tabs."""
+    visual_pos = 0
+    for char in s:
+        visual_pos += get_char_width(char, visual_pos)
+    return visual_pos
 
 
 def get_true_position(line, target_col):
-    """Calculate true position accounting for wide characters"""
+    """Convert visual column to string index, accounting for wide chars and tabs."""
     visual_pos = 0
     true_pos = 0
     while true_pos < len(line) and visual_pos < target_col:
-        char_width = get_char_width(line[true_pos])
+        char_width = get_char_width(line[true_pos], visual_pos)
         visual_pos += char_width
         true_pos += 1
     return true_pos
@@ -725,7 +782,7 @@ def find_matches(
                         matched = substring.lower() == pattern.lower()
 
                     if matched:
-                        visual_col = sum(get_char_width(c) for c in line[:pos])
+                        visual_col = get_string_width(line[:pos])
                         matches.append((pane, line_num, visual_col))
                         break  # Found match, no need to check other patterns
 

--- a/easymotion.py
+++ b/easymotion.py
@@ -492,82 +492,37 @@ def tmux_capture_pane(pane):
 
 
 def tmux_move_cursor(pane, line_num, true_col):
-    # Execute commands sequentially
-    cmds = [["tmux", "select-pane", "-t", pane.pane_id]]
-
+    pid = pane.pane_id
+    cmds = [["tmux", "select-pane", "-t", pid]]
     if not pane.copy_mode:
-        cmds.append(["tmux", "copy-mode", "-t", pane.pane_id])
+        cmds.append(["tmux", "copy-mode", "-t", pid])
 
-    cmds.append(["tmux", "send-keys", "-X", "-t", pane.pane_id, "top-line"])
-    # Ensure we always start from column 0 of the *screen line*; doing this
-    # before moving down avoids "start-of-line" jumping to the beginning of a
-    # wrapped *logical* line.
-    cmds.append(["tmux", "send-keys", "-X", "-t", pane.pane_id, "start-of-line"])
+    def x(*args):
+        cmds.append(["tmux", "send-keys", "-X", "-t", pid, *args])
 
-    # tmux's copy-mode cursor-down maintains an "at end of line" bias via
-    # internal lastcx/lastsx state. When the top of the pane has empty rows,
-    # that state is never primed (cursor-down on an empty row does not
-    # update lastsx), so subsequent cursor-down -N pulls the cursor to the
-    # end of every non-empty row it crosses. Walk down to the first
-    # non-empty row, run start-of-line to set lastsx > 0, then walk back
-    # so the user-visible jump starts from a clean (0, 0) with primed state.
+    # start-of-line on row 0 (instead of after cursor-down) so it can't
+    # walk into a wrapped *logical* line above the target — issue #18.
+    x("top-line")
+    x("start-of-line")
+
+    # tmux's cursor-down keeps an "at end of line" bias via lastcx/lastsx.
+    # cursor-down on an empty row never updates lastsx, so a later
+    # cursor-down -N drags the cursor to the end of every non-empty row
+    # it crosses (visible on tmux 3.6+ when the pane has leading empty
+    # rows, e.g. Claude Code's UI). Walk to the first non-empty row and
+    # run start-of-line to prime lastsx > 0, then absorb the walk into
+    # the main descent so we don't pay an extra cursor-up round-trip.
     first_non_empty = next((i for i, line in enumerate(pane.lines) if line), 0)
-    if first_non_empty > 0:
-        cmds.append(
-            [
-                "tmux",
-                "send-keys",
-                "-X",
-                "-t",
-                pane.pane_id,
-                "-N",
-                str(first_non_empty),
-                "cursor-down",
-            ]
-        )
-        cmds.append(
-            ["tmux", "send-keys", "-X", "-t", pane.pane_id, "start-of-line"]
-        )
-        cmds.append(
-            [
-                "tmux",
-                "send-keys",
-                "-X",
-                "-t",
-                pane.pane_id,
-                "-N",
-                str(first_non_empty),
-                "cursor-up",
-            ]
-        )
+    rows_remaining = line_num
+    if 0 < first_non_empty <= line_num:
+        x("-N", str(first_non_empty), "cursor-down")
+        x("start-of-line")
+        rows_remaining -= first_non_empty
 
-    if line_num > 0:
-        cmds.append(
-            [
-                "tmux",
-                "send-keys",
-                "-X",
-                "-t",
-                pane.pane_id,
-                "-N",
-                str(line_num),
-                "cursor-down",
-            ]
-        )
-
+    if rows_remaining > 0:
+        x("-N", str(rows_remaining), "cursor-down")
     if true_col > 0:
-        cmds.append(
-            [
-                "tmux",
-                "send-keys",
-                "-X",
-                "-t",
-                pane.pane_id,
-                "-N",
-                str(true_col),
-                "cursor-right",
-            ]
-        )
+        x("-N", str(true_col), "cursor-right")
 
     for cmd in cmds:
         sh(cmd)

--- a/easymotion.py
+++ b/easymotion.py
@@ -504,6 +504,43 @@ def tmux_move_cursor(pane, line_num, true_col):
     # wrapped *logical* line.
     cmds.append(["tmux", "send-keys", "-X", "-t", pane.pane_id, "start-of-line"])
 
+    # tmux's copy-mode cursor-down maintains an "at end of line" bias via
+    # internal lastcx/lastsx state. When the top of the pane has empty rows,
+    # that state is never primed (cursor-down on an empty row does not
+    # update lastsx), so subsequent cursor-down -N pulls the cursor to the
+    # end of every non-empty row it crosses. Walk down to the first
+    # non-empty row, run start-of-line to set lastsx > 0, then walk back
+    # so the user-visible jump starts from a clean (0, 0) with primed state.
+    first_non_empty = next((i for i, line in enumerate(pane.lines) if line), 0)
+    if first_non_empty > 0:
+        cmds.append(
+            [
+                "tmux",
+                "send-keys",
+                "-X",
+                "-t",
+                pane.pane_id,
+                "-N",
+                str(first_non_empty),
+                "cursor-down",
+            ]
+        )
+        cmds.append(
+            ["tmux", "send-keys", "-X", "-t", pane.pane_id, "start-of-line"]
+        )
+        cmds.append(
+            [
+                "tmux",
+                "send-keys",
+                "-X",
+                "-t",
+                pane.pane_id,
+                "-N",
+                str(first_non_empty),
+                "cursor-up",
+            ]
+        )
+
     if line_num > 0:
         cmds.append(
             [

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -1113,6 +1113,68 @@ def test_cursor_jump_on_wrapped_line(tmux_server):
     )
 
 
+@requires_tmux
+def test_cursor_jump_with_empty_top_rows(tmux_server):
+    """Regression test: cursor-down propagated end-of-line bias on tmux 3.6+.
+
+    When the top rows of the pane are empty, tmux's copy-mode cursor-down
+    never primed its internal lastsx state, so cursor-down -N pulled the
+    cursor to the end of every non-empty row it crossed. With ``pane.lines``
+    populated, ``tmux_move_cursor`` must compensate so the user-visible
+    landing matches (target_line, target_col).
+
+    Setup mimics the real bug: row 0 empty, row N has content with the
+    target column well within line bounds.
+    """
+    pane_id = tmux_server.pane_id
+
+    # Create content where row 0 is blank and a later row has a long line.
+    # Use printf with %s\n so each argument gets its own line; the leading
+    # empty argument produces a blank row 0 (and `clear` first to reset).
+    tmux_server.send_keys(
+        'clear; printf "%s\\n" "" "AAAAAAAAAA" "BBBBBBBBBB" "short"'
+        ' "the_target_line_with_lots_of_content_here"',
+        "Enter",
+    )
+    time.sleep(0.4)
+
+    # Pane is 30x10 from the tmux_server fixture
+    pane = PaneInfo(pane_id, active=True, start_y=0, height=10, start_x=0, width=30)
+    pane.copy_mode = False
+
+    # Capture pane.lines just like easymotion does at runtime
+    capture = subprocess.run(
+        ["tmux", "-L", tmux_server.server_name, "capture-pane", "-p", "-t", pane_id],
+        capture_output=True,
+        text=True,
+    ).stdout
+    pane.lines = capture[:-1].split("\n")[: pane.height]
+
+    # Sanity: the bug only reproduces when there are leading empty rows
+    assert pane.lines[0] == "", (
+        "Test setup precondition: row 0 must be empty to exercise the bug"
+    )
+
+    # Pick a target on the long content row
+    target_line = next(i for i, line in enumerate(pane.lines) if "target_line" in line)
+    target_col = pane.lines[target_line].index("target_line")
+
+    with patch("easymotion.sh", tmux_server.make_sh_for_server()):
+        tmux_move_cursor(pane, target_line, target_col)
+
+    time.sleep(0.1)
+
+    cursor_x, cursor_y = tmux_server.get_cursor_position()
+    assert cursor_y == target_line, (
+        f"Cursor landed on row {cursor_y}, expected {target_line}. "
+        f"This indicates cursor-right wrapped past end of row "
+        f"because cursor-down ended at end-of-line instead of col 0."
+    )
+    assert cursor_x == target_col, (
+        f"Cursor at col {cursor_x}, expected {target_col}"
+    )
+
+
 # =============================================================================
 # Integration Tests - Cross-Pane Jump (Core Feature)
 # =============================================================================

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -33,18 +33,6 @@ def test_get_char_width():
     assert get_char_width(" ") == 1  # Space
     assert get_char_width("\n") == 1  # Newline
 
-    # Tab at column 0 is always 8 columns regardless of tmux version
-    assert get_char_width("\t", 0) == 8
-
-    if easymotion.TMUX_VERSION >= (3, 6):
-        # tmux 3.6+ renders tabs to the next 8-column tab stop
-        assert get_char_width("\t", 1) == 7
-        assert get_char_width("\t", 7) == 1
-    else:
-        # Older tmux renders tabs as a fixed-width 8-column glyph
-        assert get_char_width("\t", 1) == 8
-        assert get_char_width("\t", 7) == 8
-
 
 def test_get_string_width():
     assert get_string_width("hello") == 5
@@ -52,10 +40,58 @@ def test_get_string_width():
     assert get_string_width("hello こんにちは") == 16
     assert get_string_width("") == 0
 
-    # Leading tab always lands on the first tab stop
-    assert get_string_width("\t") == 8
 
-    if easymotion.TMUX_VERSION >= (3, 6):
+def test_get_true_position():
+    assert get_true_position("hello", 3) == 3
+    assert get_true_position("あいうえお", 4) == 2
+    assert get_true_position("hello あいうえお", 7) == 7
+    assert get_true_position("", 5) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tab handling — both tmux version code paths exercised on every CI run via
+# the ``tmux_mode`` fixture, regardless of which tmux is actually installed.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(params=[(3, 5), (3, 6)], ids=["tmux<3.6", "tmux>=3.6"])
+def tmux_mode(request, monkeypatch):
+    """Force easymotion to behave as the parametrized tmux version.
+
+    Patches both ``TMUX_VERSION`` and the cached
+    ``_TMUX_HAS_POSITION_AWARE_TABS`` flag, then clears the width caches so
+    pre-fixture lookups don't bleed into the test.
+    """
+    version = request.param
+    monkeypatch.setattr(easymotion, "TMUX_VERSION", version)
+    monkeypatch.setattr(
+        easymotion, "_TMUX_HAS_POSITION_AWARE_TABS", version >= (3, 6)
+    )
+    easymotion._char_width_no_tab.cache_clear()
+    easymotion.get_string_width.cache_clear()
+    yield version
+    easymotion._char_width_no_tab.cache_clear()
+    easymotion.get_string_width.cache_clear()
+
+
+def test_get_char_width_tab(tmux_mode):
+    # Tab at column 0 is always 8 columns regardless of tmux version
+    assert get_char_width("\t", 0) == 8
+
+    if tmux_mode >= (3, 6):
+        # tmux 3.6+: position-aware (next 8-column tab stop)
+        assert get_char_width("\t", 1) == 7
+        assert get_char_width("\t", 7) == 1
+    else:
+        # Older tmux: fixed-width 8-column glyph
+        assert get_char_width("\t", 1) == 8
+        assert get_char_width("\t", 7) == 8
+
+
+def test_get_string_width_tab(tmux_mode):
+    assert get_string_width("\t") == 8  # leading tab always lands on first stop
+
+    if tmux_mode >= (3, 6):
         assert get_string_width("a\t") == 8  # 1 + (8-1)
         assert get_string_width("1234567\t") == 8  # 7 + (8-7)
         assert get_string_width("a\tb\t") == 16  # 1 + 7 + 1 + 7
@@ -65,22 +101,38 @@ def test_get_string_width():
         assert get_string_width("a\tb\t") == 18  # 1 + 8 + 1 + 8
 
 
-def test_get_true_position():
-    assert get_true_position("hello", 3) == 3
-    assert get_true_position("あいうえお", 4) == 2
-    assert get_true_position("hello あいうえお", 7) == 7
-    assert get_true_position("", 5) == 0
+def test_get_true_position_tab(tmux_mode):
+    # Halfway-through-tab still maps to the tab itself, both versions
+    assert get_true_position("\t", 4) == 1
+    assert get_true_position("\t", 8) == 1
 
-    # Tabs participate in visual->index mapping
-    assert get_true_position("\t", 4) == 1  # halfway through tab still lands on it
-    assert get_true_position("\t", 8) == 1  # full tab width
-
-    if easymotion.TMUX_VERSION >= (3, 6):
-        assert get_true_position("a\tb", 5) == 2  # halfway through tab
-        assert get_true_position("a\tb", 8) == 2  # b starts at column 8
+    # 'b' lives at string index 2 in "a\tb" regardless of tmux version;
+    # the visual column it sits on differs.
+    if tmux_mode >= (3, 6):
+        # 'a' = col 0, '\t' = cols 1-7, 'b' = col 8
+        assert get_true_position("a\tb", 5) == 2  # past tab → 'b'
+        assert get_true_position("a\tb", 8) == 2  # exactly at 'b'
     else:
-        assert get_true_position("a\tb", 5) == 2  # halfway through fixed-width tab
-        assert get_true_position("a\tb", 9) == 3  # b starts at column 9
+        # 'a' = col 0, '\t' = cols 1-8, 'b' = col 9
+        assert get_true_position("a\tb", 5) == 2  # past tab → 'b'
+        assert get_true_position("a\tb", 9) == 2  # exactly at 'b'
+    assert get_true_position("a\tb", 100) == 3  # past end of string
+
+
+def test_find_matches_visual_col_after_tab(tmux_mode):
+    """Match column reported by find_matches must respect tab width."""
+    pane = PaneInfo(
+        pane_id="%0", active=True, start_y=0, height=10, start_x=0, width=80
+    )
+    pane.lines = ["a\tb"]
+
+    matches = find_matches([pane], "b")
+    assert len(matches) == 1
+    _, line_num, visual_col = matches[0]
+    assert line_num == 0
+
+    expected = 8 if tmux_mode >= (3, 6) else 9
+    assert visual_col == expected
 
 
 def test_calculate_tab_width():

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -5,11 +5,14 @@ from unittest.mock import patch
 
 import pytest
 
+import easymotion
 from easymotion import (
     Config,
     PaneInfo,
+    _detect_tmux_version,
     _get_all_tmux_options,
     assign_hints_by_distance,
+    calculate_tab_width,
     find_matches,
     generate_hints,
     generate_smartsign_patterns,
@@ -30,6 +33,18 @@ def test_get_char_width():
     assert get_char_width(" ") == 1  # Space
     assert get_char_width("\n") == 1  # Newline
 
+    # Tab at column 0 is always 8 columns regardless of tmux version
+    assert get_char_width("\t", 0) == 8
+
+    if easymotion.TMUX_VERSION >= (3, 6):
+        # tmux 3.6+ renders tabs to the next 8-column tab stop
+        assert get_char_width("\t", 1) == 7
+        assert get_char_width("\t", 7) == 1
+    else:
+        # Older tmux renders tabs as a fixed-width 8-column glyph
+        assert get_char_width("\t", 1) == 8
+        assert get_char_width("\t", 7) == 8
+
 
 def test_get_string_width():
     assert get_string_width("hello") == 5
@@ -37,12 +52,82 @@ def test_get_string_width():
     assert get_string_width("hello こんにちは") == 16
     assert get_string_width("") == 0
 
+    # Leading tab always lands on the first tab stop
+    assert get_string_width("\t") == 8
+
+    if easymotion.TMUX_VERSION >= (3, 6):
+        assert get_string_width("a\t") == 8  # 1 + (8-1)
+        assert get_string_width("1234567\t") == 8  # 7 + (8-7)
+        assert get_string_width("a\tb\t") == 16  # 1 + 7 + 1 + 7
+    else:
+        assert get_string_width("a\t") == 9  # 1 + 8
+        assert get_string_width("1234567\t") == 15  # 7 + 8
+        assert get_string_width("a\tb\t") == 18  # 1 + 8 + 1 + 8
+
 
 def test_get_true_position():
     assert get_true_position("hello", 3) == 3
     assert get_true_position("あいうえお", 4) == 2
     assert get_true_position("hello あいうえお", 7) == 7
     assert get_true_position("", 5) == 0
+
+    # Tabs participate in visual->index mapping
+    assert get_true_position("\t", 4) == 1  # halfway through tab still lands on it
+    assert get_true_position("\t", 8) == 1  # full tab width
+
+    if easymotion.TMUX_VERSION >= (3, 6):
+        assert get_true_position("a\tb", 5) == 2  # halfway through tab
+        assert get_true_position("a\tb", 8) == 2  # b starts at column 8
+    else:
+        assert get_true_position("a\tb", 5) == 2  # halfway through fixed-width tab
+        assert get_true_position("a\tb", 9) == 3  # b starts at column 9
+
+
+def test_calculate_tab_width():
+    assert calculate_tab_width(0) == 8
+    assert calculate_tab_width(1) == 7
+    assert calculate_tab_width(7) == 1
+    assert calculate_tab_width(8) == 8
+    assert calculate_tab_width(9) == 7
+    # Custom tab size
+    assert calculate_tab_width(0, tab_size=4) == 4
+    assert calculate_tab_width(3, tab_size=4) == 1
+
+
+def test_tmux_version_detection_returns_tuple():
+    version = _detect_tmux_version()
+    assert isinstance(version, tuple)
+    assert len(version) == 2
+    major, minor = version
+    assert isinstance(major, int) and isinstance(minor, int)
+    assert major >= 0 and minor >= 0
+
+
+def test_tmux_version_string_parsing():
+    """Replicates the parser inside _detect_tmux_version() for known formats."""
+    import re
+
+    cases = [
+        ("tmux 3.5", (3, 5)),
+        ("tmux 3.6a", (3, 6)),
+        ("tmux 3.0a", (3, 0)),
+        ("tmux 2.9a", (2, 9)),
+        ("tmux next-3.6", (3, 6)),
+        ("tmux next-3.7", (3, 7)),
+        ("tmux 3.1-rc", (3, 1)),
+        ("tmux 3.1-rc2", (3, 1)),
+        ("tmux 3.1c", (3, 1)),
+        ("tmux master", (0, 0)),
+        ("tmux openbsd-6.6", (0, 0)),
+        ("tmux openbsd-7.0", (0, 0)),
+    ]
+    for version_str, expected in cases:
+        if "openbsd-" in version_str or "master" in version_str:
+            result = (0, 0)
+        else:
+            match = re.search(r"(?:next-)?(\d+)\.(\d+)", version_str)
+            result = (int(match.group(1)), int(match.group(2))) if match else (0, 0)
+        assert result == expected, f"{version_str!r} -> {result}, expected {expected}"
 
 
 def test_generate_hints():

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -1114,7 +1114,7 @@ def test_cursor_jump_on_wrapped_line(tmux_server):
 
 
 @requires_tmux
-def test_cursor_jump_with_empty_top_rows(tmux_server):
+def test_cursor_jump_with_empty_top_rows():
     """Regression test: cursor-down propagated end-of-line bias on tmux 3.6+.
 
     When the top rows of the pane are empty, tmux's copy-mode cursor-down
@@ -1123,56 +1123,82 @@ def test_cursor_jump_with_empty_top_rows(tmux_server):
     populated, ``tmux_move_cursor`` must compensate so the user-visible
     landing matches (target_line, target_col).
 
-    Setup mimics the real bug: row 0 empty, row N has content with the
-    target column well within line bounds.
+    Uses a custom 80x20 server so the user's interactive shell prompt
+    can't wrap into row 0 and defeat the empty-leading-row precondition
+    on slower CI runners.
     """
-    pane_id = tmux_server.pane_id
+    server = TmuxTestServer(width=80, height=20)
+    try:
+        server.start()
+    except RuntimeError as e:
+        pytest.skip(str(e))
 
-    # Create content where row 0 is blank and a later row has a long line.
-    # Use printf with %s\n so each argument gets its own line; the leading
-    # empty argument produces a blank row 0 (and `clear` first to reset).
-    tmux_server.send_keys(
-        'clear; printf "%s\\n" "" "AAAAAAAAAA" "BBBBBBBBBB" "short"'
-        ' "the_target_line_with_lots_of_content_here"',
-        "Enter",
-    )
-    time.sleep(0.4)
+    try:
+        pane_id = server.pane_id
 
-    # Pane is 30x10 from the tmux_server fixture
-    pane = PaneInfo(pane_id, active=True, start_y=0, height=10, start_x=0, width=30)
-    pane.copy_mode = False
+        # Stage content with leading blank line so screen row 0 is empty.
+        # `clear` first wipes any prompt; sleep keeps the pane stable.
+        target_marker = "TARGET_HERE"
+        content_file = f"/tmp/easymotion_test_{uuid.uuid4().hex[:8]}.txt"
+        with open(content_file, "w") as f:
+            f.write(f"\nfirst content\nsecond content\nthird {target_marker} line\n")
 
-    # Capture pane.lines just like easymotion does at runtime
-    capture = subprocess.run(
-        ["tmux", "-L", tmux_server.server_name, "capture-pane", "-p", "-t", pane_id],
-        capture_output=True,
-        text=True,
-    ).stdout
-    pane.lines = capture[:-1].split("\n")[: pane.height]
+        server.send_keys(f"clear; cat {content_file}; sleep 30", "Enter")
 
-    # Sanity: the bug only reproduces when there are leading empty rows
-    assert pane.lines[0] == "", (
-        "Test setup precondition: row 0 must be empty to exercise the bug"
-    )
+        pane = PaneInfo(
+            pane_id, active=True, start_y=0, height=20, start_x=0, width=80
+        )
+        pane.copy_mode = False
 
-    # Pick a target on the long content row
-    target_line = next(i for i, line in enumerate(pane.lines) if "target_line" in line)
-    target_col = pane.lines[target_line].index("target_line")
+        def capture_pane_lines():
+            capture = subprocess.run(
+                [
+                    "tmux", "-L", server.server_name,
+                    "capture-pane", "-p", "-t", pane_id,
+                ],
+                capture_output=True,
+                text=True,
+            ).stdout
+            return capture[:-1].split("\n")[: pane.height]
 
-    with patch("easymotion.sh", tmux_server.make_sh_for_server()):
-        tmux_move_cursor(pane, target_line, target_col)
+        # Poll until the content appears and row 0 is empty. The pane
+        # state isn't observable until the shell finishes processing the
+        # typed command, which is timing-sensitive on slow CI runners.
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            pane.lines = capture_pane_lines()
+            target_visible = any(target_marker in line for line in pane.lines)
+            if target_visible and pane.lines[0] == "":
+                break
+            time.sleep(0.1)
+        else:
+            raise AssertionError(
+                f"Test setup did not stabilise: pane.lines[0]={pane.lines[0]!r}, "
+                f"target_visible="
+                f"{any(target_marker in line for line in pane.lines)}"
+            )
 
-    time.sleep(0.1)
+        target_line = next(
+            i for i, line in enumerate(pane.lines) if target_marker in line
+        )
+        target_col = pane.lines[target_line].index(target_marker)
 
-    cursor_x, cursor_y = tmux_server.get_cursor_position()
-    assert cursor_y == target_line, (
-        f"Cursor landed on row {cursor_y}, expected {target_line}. "
-        f"This indicates cursor-right wrapped past end of row "
-        f"because cursor-down ended at end-of-line instead of col 0."
-    )
-    assert cursor_x == target_col, (
-        f"Cursor at col {cursor_x}, expected {target_col}"
-    )
+        with patch("easymotion.sh", server.make_sh_for_server()):
+            tmux_move_cursor(pane, target_line, target_col)
+
+        time.sleep(0.1)
+
+        cursor_x, cursor_y = server.get_cursor_position()
+        assert cursor_y == target_line, (
+            f"Cursor landed on row {cursor_y}, expected {target_line}. "
+            f"This indicates cursor-right wrapped past end of row because "
+            f"cursor-down ended at end-of-line instead of col 0."
+        )
+        assert cursor_x == target_col, (
+            f"Cursor at col {cursor_x}, expected {target_col}"
+        )
+    finally:
+        server.stop()
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Detect installed tmux version at module load and switch tab-width calculation accordingly. tmux 3.6 changed tab rendering to be position-aware (advance to the next 8-column tab stop, terminal-correct); older tmux always rendered tabs as a fixed 8-column glyph.
- Without this, hint placement and cursor jumps land on the wrong column whenever a line contains tabs on tmux 3.6+.
- Pre-3.6 fixed-width behaviour is preserved as the fallback (also covers `tmux master` and `tmux openbsd-*` build strings, where the version string can't be parsed reliably), so existing setups keep working unchanged.

## Implementation notes

- `_detect_tmux_version()` parses the common `tmux -V` formats (`3.6a`, `next-3.6`, `3.1-rc2`, etc.) and returns `(0, 0)` on any failure.
- `get_char_width(char, position=0)` gains an optional `position` argument that is only consulted for tabs. Non-tab chars still hit the existing `lru_cache` via a private helper, so the cache is **not** polluted by per-column entries.
- `get_string_width()` and `get_true_position()` track the running visual position so tabs work mid-line.
- One inline `sum(get_char_width(c) for c in line[:pos])` in `find_matches()` is replaced with `get_string_width(line[:pos])` so the match column stays correct after tabs.

## Background

Closes the work originally proposed in #3, which had drifted ~1300 lines behind master. The other two commits in #3 (`save temp keystroke file in tmp dir`, `escape hints`) are obsolete on current master because #16 refactored the keystroke flow to use `tmux command-prompt -F` instead of temp files. After this lands, #3 can be closed.

## Test plan

- [x] `pytest test_easymotion.py -v --cache-clear` — 50 / 50 pass on tmux 3.6a (local)
- [x] `make lint` — `ruff` + `pyright` clean
- [x] Verified both code paths by monkey-patching `TMUX_VERSION`:
  - `(3, 5)`: `get_string_width('a\t')` == 9, `get_char_width('\t', 1)` == 8
  - `(3, 6)`: `get_string_width('a\t')` == 8, `get_char_width('\t', 1)` == 7
- [ ] Manual verification on a real tmux 3.6 session with tabbed content (e.g. `printf 'a\tb\tc\n'` then trigger easymotion)
- [ ] Manual verification on tmux < 3.6 to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)