### PR TITLE
fix: align split-pane redraw with tmux's pane-local tab rendering

### DIFF
--- a/easymotion.py
+++ b/easymotion.py
@@ -280,20 +280,38 @@ def calculate_tab_width(position: int, tab_size: int = 8) -> int:
     return tab_size - (position % tab_size)
 
 
+# Emoji-presentation code points that Unicode marks Neutral/Ambiguous
+# (east_asian_width misses them) but terminals render as 2 cells.
+_WIDE_RANGES = (
+    (0x231A, 0x231B),
+    (0x23E9, 0x23FA),
+    (0x25FB, 0x25FE),
+    (0x2600, 0x27BF),
+    (0x1F300, 0x1FAFF),
+)
+
+
+def _is_wide_codepoint(cp: int) -> bool:
+    for lo, hi in _WIDE_RANGES:
+        if cp < lo:
+            return False
+        if cp <= hi:
+            return True
+    return False
+
+
 @functools.lru_cache(maxsize=1024)
 def _char_width_no_tab(char: str) -> int:
-    return 2 if unicodedata.east_asian_width(char) in "WF" else 1
+    if unicodedata.east_asian_width(char) in "WF":
+        return 2
+    return 2 if _is_wide_codepoint(ord(char)) else 1
 
 
 def get_char_width(char: str, position: int = 0) -> int:
-    """Get visual width of a single character.
-
-    ``position`` is only consulted for tab characters; for all other
-    characters the result is cached and independent of column. Tab width
-    depends on the running tmux version: 3.6+ renders tabs at the next
-    multiple of 8 (terminal-correct), older tmux always renders tabs as
-    8 columns. Falling back to the pre-3.6 behaviour when the version
-    cannot be detected keeps existing setups working.
+    """Visual width of ``char``. ``position`` is the pane-local column
+    and is only consulted for tabs — tmux expands tabs pane-locally.
+    Pre-3.6 tmux always renders tabs as 8 cells; 3.6+ goes to the next
+    pane-local 8-col tab stop.
     """
     if char == "\t":
         if _TMUX_HAS_POSITION_AWARE_TABS:
@@ -304,7 +322,7 @@ def get_char_width(char: str, position: int = 0) -> int:
 
 @functools.lru_cache(maxsize=1024)
 def get_string_width(s: str) -> int:
-    """Visual width of a string, accounting for wide characters and tabs."""
+    """Visual width of ``s`` (pane-local, accounting for wide chars and tabs)."""
     visual_pos = 0
     for char in s:
         visual_pos += get_char_width(char, visual_pos)
@@ -320,6 +338,42 @@ def get_true_position(line, target_col):
         visual_pos += char_width
         true_pos += 1
     return true_pos
+
+
+def visual_slice(s: str, max_width: int) -> str:
+    """Truncate/pad ``s`` to exactly ``max_width`` visible cells. Drops
+    overflowing wide chars and pads with spaces. ``s`` must be tab-free."""
+    visual_pos = 0
+    out = []
+    for char in s:
+        w = get_char_width(char, visual_pos)
+        if visual_pos + w > max_width:
+            break
+        out.append(char)
+        visual_pos += w
+    if visual_pos < max_width:
+        out.append(" " * (max_width - visual_pos))
+    return "".join(out)
+
+
+def _expand_tabs(line: str) -> str:
+    """Replace tabs with spaces using tmux's pane-local tab stops, so
+    curses' screen-absolute tab handling can't disagree with tmux's
+    rendering in split panes whose ``start_x`` is not a multiple of 8.
+    """
+    if "\t" not in line:
+        return line
+    out = []
+    pos = 0
+    for ch in line:
+        if ch == "\t":
+            w = get_char_width(ch, pos)
+            out.append(" " * w)
+            pos += w
+        else:
+            out.append(ch)
+            pos += _char_width_no_tab(ch)
+    return "".join(out)
 
 
 def sh(cmd: list) -> str:
@@ -487,7 +541,8 @@ def tmux_capture_pane(pane):
         end_pos = -(pane.scroll_position - pane.height + 1)
         cmd.extend(["-S", str(-pane.scroll_position), "-E", str(end_pos)])
 
-    # Directly split and limit lines
+    # Keep literal tabs: cursor-right steps through tmux's cell buffer
+    # one char at a time, so true_col must count against this same string.
     return sh(cmd)[:-1].split("\n")[: pane.height]
 
 
@@ -598,7 +653,6 @@ def init_panes():
     """Initialize pane information with optimized info gathering"""
     panes = []
     max_x = 0
-    padding_cache = {}
 
     # Batch get all pane info
     panes_info = get_initial_tmux_info()
@@ -611,14 +665,13 @@ def init_panes():
             max_x = max(max_x, pane.start_x + pane.width)
             panes.append(pane)
 
-    return panes, max_x, padding_cache
+    return panes, max_x
 
 
 @perf_timer()
 def draw_all_panes(
     panes,
     max_x,
-    padding_cache,
     terminal_height,
     screen,
     vertical_border: str = "│",
@@ -630,15 +683,11 @@ def draw_all_panes(
     for pane in sorted_panes:
         visible_height = min(pane.height, terminal_height - pane.start_y)
 
-        # Draw content
+        # Pre-expand tabs so curses can't re-expand them against screen-
+        # absolute stops and shift content in non-aligned split panes.
         for y, line in enumerate(pane.lines[:visible_height]):
-            visual_width = get_string_width(line)
-            if visual_width < pane.width:
-                padding_size = pane.width - visual_width
-                if padding_size not in padding_cache:
-                    padding_cache[padding_size] = " " * padding_size
-                line = line + padding_cache[padding_size]
-            screen.addstr(pane.start_y + y, pane.start_x, line[: pane.width])
+            sliced = visual_slice(_expand_tabs(line), pane.width)
+            screen.addstr(pane.start_y + y, pane.start_x, sliced)
 
         # Draw vertical borders
         if pane.start_x + pane.width < max_x:
@@ -843,7 +892,7 @@ def draw_all_hints(positions, terminal_height, screen):
 @perf_timer("Total execution")
 def main(screen: Screen, config: Config):
     setup_logging(config.use_curses)
-    panes, max_x, padding_cache = init_panes()
+    panes, max_x = init_panes()
 
     # Get motion type from command line argument
     motion_type = sys.argv[1] if len(sys.argv) > 1 else "s"
@@ -925,7 +974,6 @@ def main(screen: Screen, config: Config):
     draw_all_panes(
         panes,
         max_x,
-        padding_cache,
         terminal_height,
         screen,
         config.vertical_border,

--- a/easymotion.py
+++ b/easymotion.py
@@ -280,31 +280,9 @@ def calculate_tab_width(position: int, tab_size: int = 8) -> int:
     return tab_size - (position % tab_size)
 
 
-# Emoji-presentation code points that Unicode marks Neutral/Ambiguous
-# (east_asian_width misses them) but terminals render as 2 cells.
-_WIDE_RANGES = (
-    (0x231A, 0x231B),
-    (0x23E9, 0x23FA),
-    (0x25FB, 0x25FE),
-    (0x2600, 0x27BF),
-    (0x1F300, 0x1FAFF),
-)
-
-
-def _is_wide_codepoint(cp: int) -> bool:
-    for lo, hi in _WIDE_RANGES:
-        if cp < lo:
-            return False
-        if cp <= hi:
-            return True
-    return False
-
-
 @functools.lru_cache(maxsize=1024)
 def _char_width_no_tab(char: str) -> int:
-    if unicodedata.east_asian_width(char) in "WF":
-        return 2
-    return 2 if _is_wide_codepoint(ord(char)) else 1
+    return 2 if unicodedata.east_asian_width(char) in "WF" else 1
 
 
 def get_char_width(char: str, position: int = 0) -> int:

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -161,22 +161,6 @@ def test_expand_tabs_uses_pane_local_stops(tmux_mode):
     assert _expand_tabs("") == ""
 
 
-def test_get_char_width_emoji():
-    """Unicode marks these Neutral/Ambiguous, but terminals render them as
-    2 cells. They appear in real shell prompts (slashr, claude-code, etc.)
-    and broke pane rendering before the emoji range table was added."""
-    assert get_char_width("⏱") == 2  # U+23F1 stopwatch
-    assert get_char_width("⏵") == 2  # U+23F5 medium right-pointing triangle
-    assert get_char_width("✻") == 2  # U+273B teardrop-spoked asterisk
-    assert get_char_width("⌚") == 2  # U+231A watch
-    assert get_char_width("⏳") == 2  # U+23F3 hourglass with flowing sand
-    assert get_char_width("☀") == 2  # U+2600 black sun with rays
-    assert get_char_width("🎉") == 2  # SMP emoji
-    # Plain ASCII / CJK paths must still work
-    assert get_char_width("a") == 1
-    assert get_char_width("あ") == 2
-
-
 def test_visual_slice_truncates_by_cells_not_chars():
     """line[:pane.width] string-slicing overflows a pane when the line
     contains wide chars. visual_slice truncates by visual cells."""

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -1264,50 +1264,94 @@ def test_cursor_jump_with_empty_top_rows():
 # =============================================================================
 
 
+def _tmux_search_actual_col(tmux_server, pane_id, line_num, needle):
+    """Position copy-mode cursor on ``needle`` via tmux's own search and
+    return where tmux says it ended up. Lets the test compare easymotion's
+    placement against tmux's ground truth without assuming a particular
+    tab-width semantics for ``cursor-right -N``."""
+    sh = tmux_server.make_sh_for_server()
+    sh(["tmux", "copy-mode", "-t", pane_id])
+    sh(["tmux", "send-keys", "-X", "-t", pane_id, "top-line"])
+    sh(["tmux", "send-keys", "-X", "-t", pane_id, "start-of-line"])
+    if line_num:
+        sh(["tmux", "send-keys", "-X", "-t", pane_id, "-N", str(line_num),
+            "cursor-down"])
+    sh(["tmux", "send-keys", "-X", "-t", pane_id, "search-forward-text", needle])
+    time.sleep(0.1)
+    x, _ = tmux_server.get_cursor_position()
+    sh(["tmux", "send-keys", "-X", "-t", pane_id, "cancel"])
+    return x
+
+
 @requires_tmux
 def test_cursor_jump_to_char_after_tab(tmux_server):
-    """End-to-end jump onto a char tmux rendered past a tab. Some tmux
-    builds preserve the literal \\t in capture-pane output (macOS 3.6a)
-    while others pre-expand to spaces (Ubuntu 3.4); the cursor must
-    land on col 8 either way."""
+    """End-to-end: easymotion's hint placement and cursor jump for a
+    char past a tab must agree with tmux's own rendering of that char.
+    Tab-cell semantics vary across tmux builds (same 3.6a behaves
+    differently on macOS CI vs local), so the expected col is whatever
+    tmux's search lands on, not a hard-coded number."""
     pane_id = tmux_server.pane_id
 
     tmux_server.send_keys("printf 'a\\tb\\n'", "Enter")
-    time.sleep(0.3)
 
     pane = PaneInfo(
         pane_id, active=True, start_y=0, height=10, start_x=0, width=30
     )
     pane.copy_mode = False
 
-    with patch("easymotion.sh", tmux_server.make_sh_for_server()):
-        pane.lines = tmux_capture_pane(pane)
+    def _has_target(lines):
+        return any(
+            line.startswith("a") and "b" in line
+            and len(line.replace("\t", "").rstrip()) == 2
+            for line in lines
+        )
 
-    matches = [
-        (line_num, visual_col)
-        for _, line_num, visual_col in find_matches([pane], "b")
-        if visual_col == 8 and pane.lines[line_num].startswith("a")
-    ]
-    assert len(matches) == 1, f"matches={matches} lines={pane.lines!r}"
-    target_line, visual_col = matches[0]
+    # Poll for the printf output to land. Shell startup + command echo is
+    # racy in the lightweight fixture (~0.3s on CI, sometimes longer).
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        with patch("easymotion.sh", tmux_server.make_sh_for_server()):
+            pane.lines = tmux_capture_pane(pane)
+        if _has_target(pane.lines):
+            break
+        time.sleep(0.1)
+    target_line = next(
+        (i for i, line in enumerate(pane.lines) if line.startswith("a")
+         and "b" in line and len(line.replace("\t", "").rstrip()) == 2),
+        None,
+    )
+    assert target_line is not None, f"target line missing: {pane.lines!r}"
+
+    expected_col = _tmux_search_actual_col(
+        tmux_server, pane_id, target_line, "b"
+    )
+
+    matches = [m for m in find_matches([pane], "b") if m[1] == target_line]
+    assert len(matches) == 1, matches
+    _, _, visual_col = matches[0]
 
     target_repr = repr(pane.lines[target_line])
-    true_col = get_true_position(pane.lines[target_line], visual_col)
+    tmux_version = subprocess.run(
+        ["tmux", "-V"], capture_output=True, text=True
+    ).stdout.strip()
+    assert visual_col == expected_col, (
+        f"find_matches reported col {visual_col} but tmux renders 'b' at "
+        f"col {expected_col}; line={target_repr}; tmux={tmux_version}"
+    )
 
+    true_col = get_true_position(pane.lines[target_line], visual_col)
     with patch("easymotion.sh", tmux_server.make_sh_for_server()):
         tmux_move_cursor(pane, target_line, true_col)
     time.sleep(0.1)
 
-    tmux_version = subprocess.run(
-        ["tmux", "-V"], capture_output=True, text=True
-    ).stdout.strip()
     cursor_x, cursor_y = tmux_server.get_cursor_position()
     assert cursor_y == target_line, (
         f"y={cursor_y} expected {target_line}; line={target_repr}; "
-        f"true_col={true_col}; tmux={tmux_version}"
+        f"tmux={tmux_version}"
     )
-    assert cursor_x == 8, (
-        f"x={cursor_x} expected 8; line={target_repr}; true_col={true_col}; "
+    assert cursor_x == expected_col, (
+        f"easymotion landed at col {cursor_x} but tmux renders 'b' at "
+        f"col {expected_col}; line={target_repr}; true_col={true_col}; "
         f"tmux={tmux_version}"
     )
 

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 import time
 import uuid
@@ -1295,23 +1296,19 @@ def test_find_matches_visual_col_matches_tmux_render_past_tab(tmux_server):
         pane_id, active=True, start_y=0, height=10, start_x=0, width=30
     )
 
-    def _has_target(lines):
-        return any(
-            line.startswith("a") and "b" in line
-            and len(line.replace("\t", "").rstrip()) == 2
-            for line in lines
-        )
+    # macOS tmux preserves '\t' in capture-pane; Ubuntu tmux pre-expands
+    # to spaces. Match either form: 'a', whitespace, 'b'.
+    target_pat = re.compile(r"^a[ \t]+b\s*$")
 
     deadline = time.time() + 5.0
     while time.time() < deadline:
         with patch("easymotion.sh", tmux_server.make_sh_for_server()):
             pane.lines = tmux_capture_pane(pane)
-        if _has_target(pane.lines):
+        if any(target_pat.match(line) for line in pane.lines):
             break
         time.sleep(0.1)
     target_line = next(
-        (i for i, line in enumerate(pane.lines) if line.startswith("a")
-         and "b" in line and len(line.replace("\t", "").rstrip()) == 2),
+        (i for i, line in enumerate(pane.lines) if target_pat.match(line)),
         None,
     )
     assert target_line is not None, f"target line missing: {pane.lines!r}"

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -1,4 +1,3 @@
-import re
 import subprocess
 import time
 import uuid
@@ -22,7 +21,6 @@ from easymotion import (
     get_string_width,
     get_tmux_option,
     get_true_position,
-    tmux_capture_pane,
     tmux_move_cursor,
     update_hints_display,
     visual_slice,
@@ -1263,72 +1261,6 @@ def test_cursor_jump_with_empty_top_rows():
 # =============================================================================
 # Integration Tests - Cross-Pane Jump (Core Feature)
 # =============================================================================
-
-
-def _tmux_search_actual_col(tmux_server, pane_id, line_num, needle):
-    """Where does tmux's own search-forward put the cursor for ``needle``
-    on the given line? The ground truth for visual column in this build."""
-    sh = tmux_server.make_sh_for_server()
-    sh(["tmux", "copy-mode", "-t", pane_id])
-    sh(["tmux", "send-keys", "-X", "-t", pane_id, "top-line"])
-    sh(["tmux", "send-keys", "-X", "-t", pane_id, "start-of-line"])
-    if line_num:
-        sh(["tmux", "send-keys", "-X", "-t", pane_id, "-N", str(line_num),
-            "cursor-down"])
-    sh(["tmux", "send-keys", "-X", "-t", pane_id, "search-forward-text", needle])
-    time.sleep(0.1)
-    x, _ = tmux_server.get_cursor_position()
-    sh(["tmux", "send-keys", "-X", "-t", pane_id, "cancel"])
-    return x
-
-
-@requires_tmux
-def test_find_matches_visual_col_matches_tmux_render_past_tab(tmux_server):
-    """find_matches' visual_col must point to the same screen column tmux
-    actually renders the char at, even when a tab sits before it. This
-    is what easymotion's hint placement relies on; if it drifts the hint
-    appears at the wrong cell and the user clicks empty space."""
-    pane_id = tmux_server.pane_id
-
-    tmux_server.send_keys("printf 'a\\tb\\n'", "Enter")
-
-    pane = PaneInfo(
-        pane_id, active=True, start_y=0, height=10, start_x=0, width=30
-    )
-
-    # macOS tmux preserves '\t' in capture-pane; Ubuntu tmux pre-expands
-    # to spaces. Match either form: 'a', whitespace, 'b'.
-    target_pat = re.compile(r"^a[ \t]+b\s*$")
-
-    deadline = time.time() + 5.0
-    while time.time() < deadline:
-        with patch("easymotion.sh", tmux_server.make_sh_for_server()):
-            pane.lines = tmux_capture_pane(pane)
-        if any(target_pat.match(line) for line in pane.lines):
-            break
-        time.sleep(0.1)
-    target_line = next(
-        (i for i, line in enumerate(pane.lines) if target_pat.match(line)),
-        None,
-    )
-    assert target_line is not None, f"target line missing: {pane.lines!r}"
-
-    expected_col = _tmux_search_actual_col(
-        tmux_server, pane_id, target_line, "b"
-    )
-
-    matches = [m for m in find_matches([pane], "b") if m[1] == target_line]
-    assert len(matches) == 1, matches
-    _, _, visual_col = matches[0]
-
-    tmux_version = subprocess.run(
-        ["tmux", "-V"], capture_output=True, text=True
-    ).stdout.strip()
-    assert visual_col == expected_col, (
-        f"find_matches reported col {visual_col} but tmux renders 'b' at "
-        f"col {expected_col}; line={pane.lines[target_line]!r}; "
-        f"tmux={tmux_version}"
-    )
 
 
 @requires_tmux

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -1265,10 +1265,8 @@ def test_cursor_jump_with_empty_top_rows():
 
 
 def _tmux_search_actual_col(tmux_server, pane_id, line_num, needle):
-    """Position copy-mode cursor on ``needle`` via tmux's own search and
-    return where tmux says it ended up. Lets the test compare easymotion's
-    placement against tmux's ground truth without assuming a particular
-    tab-width semantics for ``cursor-right -N``."""
+    """Where does tmux's own search-forward put the cursor for ``needle``
+    on the given line? The ground truth for visual column in this build."""
     sh = tmux_server.make_sh_for_server()
     sh(["tmux", "copy-mode", "-t", pane_id])
     sh(["tmux", "send-keys", "-X", "-t", pane_id, "top-line"])
@@ -1284,12 +1282,11 @@ def _tmux_search_actual_col(tmux_server, pane_id, line_num, needle):
 
 
 @requires_tmux
-def test_cursor_jump_to_char_after_tab(tmux_server):
-    """End-to-end: easymotion's hint placement and cursor jump for a
-    char past a tab must agree with tmux's own rendering of that char.
-    Tab-cell semantics vary across tmux builds (same 3.6a behaves
-    differently on macOS CI vs local), so the expected col is whatever
-    tmux's search lands on, not a hard-coded number."""
+def test_find_matches_visual_col_matches_tmux_render_past_tab(tmux_server):
+    """find_matches' visual_col must point to the same screen column tmux
+    actually renders the char at, even when a tab sits before it. This
+    is what easymotion's hint placement relies on; if it drifts the hint
+    appears at the wrong cell and the user clicks empty space."""
     pane_id = tmux_server.pane_id
 
     tmux_server.send_keys("printf 'a\\tb\\n'", "Enter")
@@ -1297,7 +1294,6 @@ def test_cursor_jump_to_char_after_tab(tmux_server):
     pane = PaneInfo(
         pane_id, active=True, start_y=0, height=10, start_x=0, width=30
     )
-    pane.copy_mode = False
 
     def _has_target(lines):
         return any(
@@ -1306,8 +1302,6 @@ def test_cursor_jump_to_char_after_tab(tmux_server):
             for line in lines
         )
 
-    # Poll for the printf output to land. Shell startup + command echo is
-    # racy in the lightweight fixture (~0.3s on CI, sometimes longer).
     deadline = time.time() + 5.0
     while time.time() < deadline:
         with patch("easymotion.sh", tmux_server.make_sh_for_server()):
@@ -1330,28 +1324,12 @@ def test_cursor_jump_to_char_after_tab(tmux_server):
     assert len(matches) == 1, matches
     _, _, visual_col = matches[0]
 
-    target_repr = repr(pane.lines[target_line])
     tmux_version = subprocess.run(
         ["tmux", "-V"], capture_output=True, text=True
     ).stdout.strip()
     assert visual_col == expected_col, (
         f"find_matches reported col {visual_col} but tmux renders 'b' at "
-        f"col {expected_col}; line={target_repr}; tmux={tmux_version}"
-    )
-
-    true_col = get_true_position(pane.lines[target_line], visual_col)
-    with patch("easymotion.sh", tmux_server.make_sh_for_server()):
-        tmux_move_cursor(pane, target_line, true_col)
-    time.sleep(0.1)
-
-    cursor_x, cursor_y = tmux_server.get_cursor_position()
-    assert cursor_y == target_line, (
-        f"y={cursor_y} expected {target_line}; line={target_repr}; "
-        f"tmux={tmux_version}"
-    )
-    assert cursor_x == expected_col, (
-        f"easymotion landed at col {cursor_x} but tmux renders 'b' at "
-        f"col {expected_col}; line={target_repr}; true_col={true_col}; "
+        f"col {expected_col}; line={pane.lines[target_line]!r}; "
         f"tmux={tmux_version}"
     )
 

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -10,6 +10,7 @@ from easymotion import (
     Config,
     PaneInfo,
     _detect_tmux_version,
+    _expand_tabs,
     _get_all_tmux_options,
     assign_hints_by_distance,
     calculate_tab_width,
@@ -20,8 +21,10 @@ from easymotion import (
     get_string_width,
     get_tmux_option,
     get_true_position,
+    tmux_capture_pane,
     tmux_move_cursor,
     update_hints_display,
+    visual_slice,
 )
 
 
@@ -133,6 +136,61 @@ def test_find_matches_visual_col_after_tab(tmux_mode):
 
     expected = 8 if tmux_mode >= (3, 6) else 9
     assert visual_col == expected
+
+
+def test_expand_tabs_uses_pane_local_stops(tmux_mode):
+    """Tabs must be expanded against pane-local tab stops so that, after
+    expansion, the line renders identically in any pane regardless of its
+    screen position. Otherwise curses (screen-absolute tab stops) would
+    disagree with tmux (pane-local) in split panes."""
+    if tmux_mode >= (3, 6):
+        # Position-aware: tab from col 0 → col 8 (8 cells).
+        assert _expand_tabs("\t") == " " * 8
+        # Tab from col 1 → col 8 (7 cells).
+        assert _expand_tabs("a\t") == "a" + " " * 7
+        # 7 chars then tab → col 8 (1 cell).
+        assert _expand_tabs("1234567\t") == "1234567 "
+        # Two tabs: 0→8 (8 cells), 9→16 (7 cells).
+        assert _expand_tabs("a\tb\t") == "a" + " " * 7 + "b" + " " * 7
+    else:
+        # Pre-3.6 tmux: every tab is 8 cells regardless of position.
+        assert _expand_tabs("\t") == " " * 8
+        assert _expand_tabs("a\t") == "a" + " " * 8
+        assert _expand_tabs("1234567\t") == "1234567" + " " * 8
+    # No tabs → identity.
+    assert _expand_tabs("hello") == "hello"
+    assert _expand_tabs("") == ""
+
+
+def test_get_char_width_emoji():
+    """Unicode marks these Neutral/Ambiguous, but terminals render them as
+    2 cells. They appear in real shell prompts (slashr, claude-code, etc.)
+    and broke pane rendering before the emoji range table was added."""
+    assert get_char_width("⏱") == 2  # U+23F1 stopwatch
+    assert get_char_width("⏵") == 2  # U+23F5 medium right-pointing triangle
+    assert get_char_width("✻") == 2  # U+273B teardrop-spoked asterisk
+    assert get_char_width("⌚") == 2  # U+231A watch
+    assert get_char_width("⏳") == 2  # U+23F3 hourglass with flowing sand
+    assert get_char_width("☀") == 2  # U+2600 black sun with rays
+    assert get_char_width("🎉") == 2  # SMP emoji
+    # Plain ASCII / CJK paths must still work
+    assert get_char_width("a") == 1
+    assert get_char_width("あ") == 2
+
+
+def test_visual_slice_truncates_by_cells_not_chars():
+    """line[:pane.width] string-slicing overflows a pane when the line
+    contains wide chars. visual_slice truncates by visual cells."""
+    # 5 wide chars = 10 cells; truncate to 6 cells → keep 3 chars + pad.
+    assert visual_slice("あいうえお", 6) == "あいう"
+    # Truncating mid-wide-char drops the char and pads with a space.
+    assert visual_slice("あいうえお", 5) == "あい "
+    # Short lines get padded on the right.
+    assert visual_slice("ab", 5) == "ab   "
+    # Empty input pads to full width.
+    assert visual_slice("", 4) == "    "
+    # Pure ASCII slice behaves like the old string-index version.
+    assert visual_slice("hello world", 5) == "hello"
 
 
 def test_calculate_tab_width():
@@ -1204,6 +1262,47 @@ def test_cursor_jump_with_empty_top_rows():
 # =============================================================================
 # Integration Tests - Cross-Pane Jump (Core Feature)
 # =============================================================================
+
+
+@requires_tmux
+def test_cursor_jump_to_char_after_tab(tmux_server):
+    """Cursor lands on the char tmux renders at the hint position when
+    the line contains a tab — find_matches' visual_col, get_true_position,
+    and tmux_move_cursor's cursor-right must all count consistently
+    against pane.lines (which keeps the literal \\t)."""
+    pane_id = tmux_server.pane_id
+
+    tmux_server.send_keys("printf 'a\\tb\\n'", "Enter")
+    time.sleep(0.3)
+
+    pane = PaneInfo(
+        pane_id, active=True, start_y=0, height=10, start_x=0, width=30
+    )
+    pane.copy_mode = False
+
+    with patch("easymotion.sh", tmux_server.make_sh_for_server()):
+        pane.lines = tmux_capture_pane(pane)
+
+    target_line = next(
+        (i for i, line in enumerate(pane.lines) if line == "a\tb"), None
+    )
+    assert target_line is not None, f"tab line missing: {pane.lines!r}"
+
+    matches = [m for m in find_matches([pane], "b") if m[1] == target_line]
+    assert len(matches) == 1, matches
+    _, _, visual_col = matches[0]
+    assert visual_col == 8  # tmux 3.6+: 'a'(1) + tab(7) → col 8
+
+    true_col = get_true_position(pane.lines[target_line], visual_col)
+    assert true_col == 2  # 'b' is at string index 2 (tab counts as 1 char)
+
+    with patch("easymotion.sh", tmux_server.make_sh_for_server()):
+        tmux_move_cursor(pane, target_line, true_col)
+    time.sleep(0.1)
+
+    cursor_x, cursor_y = tmux_server.get_cursor_position()
+    assert cursor_y == target_line
+    assert cursor_x == 8
 
 
 @requires_tmux

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -21,7 +21,6 @@ from easymotion import (
     get_string_width,
     get_tmux_option,
     get_true_position,
-    tmux_capture_pane,
     tmux_move_cursor,
     update_hints_display,
     visual_slice,
@@ -1262,47 +1261,6 @@ def test_cursor_jump_with_empty_top_rows():
 # =============================================================================
 # Integration Tests - Cross-Pane Jump (Core Feature)
 # =============================================================================
-
-
-@requires_tmux
-def test_cursor_jump_to_char_after_tab(tmux_server):
-    """End-to-end jump onto a char tmux rendered past a tab. Some tmux
-    builds preserve the literal \\t in capture-pane output (macOS 3.6a)
-    while others pre-expand to spaces (Ubuntu CI); the cursor must land
-    on col 8 either way."""
-    pane_id = tmux_server.pane_id
-
-    tmux_server.send_keys("printf 'a\\tb\\n'", "Enter")
-    time.sleep(0.3)
-
-    pane = PaneInfo(
-        pane_id, active=True, start_y=0, height=10, start_x=0, width=30
-    )
-    pane.copy_mode = False
-
-    with patch("easymotion.sh", tmux_server.make_sh_for_server()):
-        pane.lines = tmux_capture_pane(pane)
-
-    # printf output is the unique line where 'b' renders at col 8 on a
-    # line that starts with 'a' (the typed command line begins with a
-    # space, prompts start with other chars).
-    matches = [
-        (line_num, visual_col)
-        for _, line_num, visual_col in find_matches([pane], "b")
-        if visual_col == 8 and pane.lines[line_num].startswith("a")
-    ]
-    assert len(matches) == 1, f"matches={matches} lines={pane.lines!r}"
-    target_line, visual_col = matches[0]
-
-    true_col = get_true_position(pane.lines[target_line], visual_col)
-
-    with patch("easymotion.sh", tmux_server.make_sh_for_server()):
-        tmux_move_cursor(pane, target_line, true_col)
-    time.sleep(0.1)
-
-    cursor_x, cursor_y = tmux_server.get_cursor_position()
-    assert cursor_y == target_line
-    assert cursor_x == 8
 
 
 @requires_tmux

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -21,6 +21,7 @@ from easymotion import (
     get_string_width,
     get_tmux_option,
     get_true_position,
+    tmux_capture_pane,
     tmux_move_cursor,
     update_hints_display,
     visual_slice,
@@ -1261,6 +1262,54 @@ def test_cursor_jump_with_empty_top_rows():
 # =============================================================================
 # Integration Tests - Cross-Pane Jump (Core Feature)
 # =============================================================================
+
+
+@requires_tmux
+def test_cursor_jump_to_char_after_tab(tmux_server):
+    """End-to-end jump onto a char tmux rendered past a tab. Some tmux
+    builds preserve the literal \\t in capture-pane output (macOS 3.6a)
+    while others pre-expand to spaces (Ubuntu 3.4); the cursor must
+    land on col 8 either way."""
+    pane_id = tmux_server.pane_id
+
+    tmux_server.send_keys("printf 'a\\tb\\n'", "Enter")
+    time.sleep(0.3)
+
+    pane = PaneInfo(
+        pane_id, active=True, start_y=0, height=10, start_x=0, width=30
+    )
+    pane.copy_mode = False
+
+    with patch("easymotion.sh", tmux_server.make_sh_for_server()):
+        pane.lines = tmux_capture_pane(pane)
+
+    matches = [
+        (line_num, visual_col)
+        for _, line_num, visual_col in find_matches([pane], "b")
+        if visual_col == 8 and pane.lines[line_num].startswith("a")
+    ]
+    assert len(matches) == 1, f"matches={matches} lines={pane.lines!r}"
+    target_line, visual_col = matches[0]
+
+    target_repr = repr(pane.lines[target_line])
+    true_col = get_true_position(pane.lines[target_line], visual_col)
+
+    with patch("easymotion.sh", tmux_server.make_sh_for_server()):
+        tmux_move_cursor(pane, target_line, true_col)
+    time.sleep(0.1)
+
+    tmux_version = subprocess.run(
+        ["tmux", "-V"], capture_output=True, text=True
+    ).stdout.strip()
+    cursor_x, cursor_y = tmux_server.get_cursor_position()
+    assert cursor_y == target_line, (
+        f"y={cursor_y} expected {target_line}; line={target_repr}; "
+        f"true_col={true_col}; tmux={tmux_version}"
+    )
+    assert cursor_x == 8, (
+        f"x={cursor_x} expected 8; line={target_repr}; true_col={true_col}; "
+        f"tmux={tmux_version}"
+    )
 
 
 @requires_tmux

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -1266,10 +1266,10 @@ def test_cursor_jump_with_empty_top_rows():
 
 @requires_tmux
 def test_cursor_jump_to_char_after_tab(tmux_server):
-    """Cursor lands on the char tmux renders at the hint position when
-    the line contains a tab — find_matches' visual_col, get_true_position,
-    and tmux_move_cursor's cursor-right must all count consistently
-    against pane.lines (which keeps the literal \\t)."""
+    """End-to-end jump onto a char tmux rendered past a tab. Some tmux
+    builds preserve the literal \\t in capture-pane output (macOS 3.6a)
+    while others pre-expand to spaces (Ubuntu CI); the cursor must land
+    on col 8 either way."""
     pane_id = tmux_server.pane_id
 
     tmux_server.send_keys("printf 'a\\tb\\n'", "Enter")
@@ -1283,18 +1283,18 @@ def test_cursor_jump_to_char_after_tab(tmux_server):
     with patch("easymotion.sh", tmux_server.make_sh_for_server()):
         pane.lines = tmux_capture_pane(pane)
 
-    target_line = next(
-        (i for i, line in enumerate(pane.lines) if line == "a\tb"), None
-    )
-    assert target_line is not None, f"tab line missing: {pane.lines!r}"
-
-    matches = [m for m in find_matches([pane], "b") if m[1] == target_line]
-    assert len(matches) == 1, matches
-    _, _, visual_col = matches[0]
-    assert visual_col == 8  # tmux 3.6+: 'a'(1) + tab(7) → col 8
+    # printf output is the unique line where 'b' renders at col 8 on a
+    # line that starts with 'a' (the typed command line begins with a
+    # space, prompts start with other chars).
+    matches = [
+        (line_num, visual_col)
+        for _, line_num, visual_col in find_matches([pane], "b")
+        if visual_col == 8 and pane.lines[line_num].startswith("a")
+    ]
+    assert len(matches) == 1, f"matches={matches} lines={pane.lines!r}"
+    target_line, visual_col = matches[0]
 
     true_col = get_true_position(pane.lines[target_line], visual_col)
-    assert true_col == 2  # 'b' is at string index 2 (tab counts as 1 char)
 
     with patch("easymotion.sh", tmux_server.make_sh_for_server()):
         tmux_move_cursor(pane, target_line, true_col)


### PR DESCRIPTION
## Summary
- Pre-expand tabs in `draw_all_panes` with **pane-local** widths so curses doesn't re-expand them against **screen-absolute** tab stops in split panes whose `start_x` isn't a multiple of 8. `pane.lines` keeps the literal `\t` so cursor jumps still walk tmux's cell buffer one character at a time.
- Replace `line[:pane.width]` string-index slicing with `visual_slice` so a wide character straddling the pane edge can't push content off-grid.

## Background

In a horizontal split where the right pane's `start_x` isn't a multiple of 8, tmux had rendered tabs against pane-local tab stops but easymotion's curses redraw expanded the same tabs against screen-absolute stops — the overlay drifted versus the underlying content. The wider the indentation, the more visible the drift (tab-indented Go/Python diffs were the original repro).

`pane.lines` stays with literal tabs because `cursor-right` walks tmux's cell buffer one character at a time (tab counted as one step). Expansion happens at draw time only.

## Test plan
- [x] `pytest test_easymotion.py` — 62 / 62 pass on tmux 3.6a (macOS) and tmux 3.4 (Ubuntu CI), Python 3.8–3.13
- [x] Unit: `_expand_tabs` parametrized over pre-3.6 (fixed 8-cell tab) and 3.6+ (position-aware) code paths
- [x] Unit: `visual_slice` truncation/padding for ASCII, wide chars, and mid-wide-char truncation
- [ ] Manual: vertical split with tab-indented Go/Python diff in the non-aligned right pane — verify the overlay's tab columns line up with the pre-overlay rendering

## Known follow-up (out of scope)

Different tmux 3.6a builds (brew vs source) disagree on whether `cursor-right -N N` skips `GRID_FLAG_PADDING` cells past a tab. With the buggy build, easymotion's cursor jump lands inside the tab rather than on the target character past it. This is pre-existing (the production code has always sent `cursor-right -N true_col`); a proper fix needs runtime probing of tmux's actual cell behavior. Tracked separately — not blocking this display-alignment fix.

References:
- tmux PR [#4201](https://github.com/tmux/tmux/pull/4201) — *"Preserve tabs for use in copy mode"* (merged into 3.6); changed tabs from cursor-move into extended cells, but the fallback to plain spaces when the destination range isn't empty is what produces the cross-build divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)