### PR TITLE
feat: custom hint colors via SGR config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Press `prefix` + `I` to install
 | `@easymotion-vertical-border` | `│` | Vertical border character |
 | `@easymotion-horizontal-border` | `─` | Horizontal border character |
 | `@easymotion-use-curses` | `false` | Use curses instead of ANSI sequences |
+| `@easymotion-hint1-fg` | `1;31` | SGR color code for the first hint character (bold red) |
+| `@easymotion-hint2-fg` | `1;32` | SGR color code for the second hint character (bold green) |
+| `@easymotion-dim` | `2` | SGR color code for the dimmed background text |
 | `@easymotion-debug` | `false` | Debug logging to ~/easymotion.log |
 | `@easymotion-perf` | `false` | Performance logging to ~/easymotion.log |
 
@@ -57,6 +60,12 @@ set -g @easymotion-s2 'f'
 set -g @easymotion-hints 'asdfghjkl;'
 set -g @easymotion-case-sensitive 'true'
 set -g @easymotion-smartsign 'true'
+
+# Custom colors (standard SGR codes: "1" bold, "4" underline,
+# "31"-"37" / "90"-"97" basic colors, "38;5;N" for 256-color)
+set -g @easymotion-hint1-fg '1;38;5;208'  # bold orange
+set -g @easymotion-hint2-fg '1;38;5;33'   # bold blue
+set -g @easymotion-dim '2;90'             # dim grey
 ```
 
 

--- a/easymotion.py
+++ b/easymotion.py
@@ -208,10 +208,10 @@ def _sgr_to_curses(codes: str):
     (foreground_color, attribute_flags) tuple for curses. Returns -1 for the
     foreground when no color is specified (keeps the terminal default).
 
-    The curses backend supports a subset of SGR: bold (1), dim (2), the basic
-    (30-37) and bright (90-97) foregrounds, and 256-color foregrounds
-    (38;5;N). Truecolor (38;2;r;g;b) and background codes are ignored; the
-    default ANSI backend honors any SGR string."""
+    The curses backend supports a subset of SGR: bold (1), dim (2), underline
+    (4), the basic (30-37) and bright (90-97) foregrounds, and 256-color
+    foregrounds (38;5;N). Truecolor (38;2;r;g;b) and background codes are
+    skipped; the default ANSI backend honors any SGR string."""
     fg = -1
     attr = 0
     parts = [p for p in codes.split(";") if p != ""]
@@ -226,17 +226,22 @@ def _sgr_to_curses(codes: str):
             attr |= curses.A_BOLD
         elif n == 2:
             attr |= curses.A_DIM
+        elif n == 4:
+            attr |= curses.A_UNDERLINE
         elif n in _SGR_BASE_COLORS:
             fg = _SGR_BASE_COLORS[n]
         elif 90 <= n <= 97:
             fg = _SGR_BASE_COLORS[n - 60]
             attr |= curses.A_BOLD
-        elif n == 38 and i + 2 < len(parts) and parts[i + 1] == "5":
-            try:
-                fg = int(parts[i + 2])
-            except ValueError:
-                pass
+        elif n == 38 and i + 1 < len(parts) and parts[i + 1] == "5":
+            if i + 2 < len(parts):
+                try:
+                    fg = int(parts[i + 2])
+                except ValueError:
+                    pass
             i += 2
+        elif n == 38 and i + 1 < len(parts) and parts[i + 1] == "2":
+            i += 4
         i += 1
     return fg, attr
 
@@ -246,18 +251,31 @@ class Curses(Screen):
         self.stdscr: Optional[curses.window] = None
         self.config = config or Config()
 
+    @staticmethod
+    def _init_pair(pair: int, fg: int):
+        """Define a foreground/default color pair, falling back to the
+        terminal default when fg is out of range for this terminal (e.g. a
+        256-color code on an 8-color TERM, which would otherwise raise)."""
+        if not 0 <= fg < curses.COLORS:
+            fg = -1
+        try:
+            curses.init_pair(pair, fg, -1)
+        except (curses.error, ValueError):
+            pass
+
     def init(self):
         self.stdscr = curses.initscr()
         curses.start_color()
         curses.use_default_colors()
         fg1, flags1 = _sgr_to_curses(self.config.hint1_fg)
         fg2, flags2 = _sgr_to_curses(self.config.hint2_fg)
-        _, flagsd = _sgr_to_curses(self.config.dim)
-        curses.init_pair(1, fg1, -1)
-        curses.init_pair(2, fg2, -1)
+        fgd, flagsd = _sgr_to_curses(self.config.dim)
+        self._init_pair(1, fg1)
+        self._init_pair(2, fg2)
+        self._init_pair(3, fgd)
         self.attr_hint1 = curses.color_pair(1) | flags1
         self.attr_hint2 = curses.color_pair(2) | flags2
-        self.attr_dim = flagsd
+        self.attr_dim = curses.color_pair(3) | flagsd
         curses.noecho()
         curses.cbreak()
         self.stdscr.keypad(True)
@@ -1049,8 +1067,8 @@ def main(screen: Screen, config: Config):
 if __name__ == "__main__":
     config = Config.from_tmux()
     screen: Screen = Curses(config) if config.use_curses else AnsiSequence(config)
-    screen.init()
     try:
+        screen.init()
         main(screen, config)
     except KeyboardInterrupt:
         logging.info("Operation cancelled by user")

--- a/easymotion.py
+++ b/easymotion.py
@@ -90,6 +90,9 @@ class Config:
         default="─", metadata={"opt": "@easymotion-horizontal-border"}
     )
     use_curses: bool = field(default=False, metadata={"opt": "@easymotion-use-curses"})
+    hint1_fg: str = field(default="1;31", metadata={"opt": "@easymotion-hint1-fg"})
+    hint2_fg: str = field(default="1;32", metadata={"opt": "@easymotion-hint2-fg"})
+    dim: str = field(default="2", metadata={"opt": "@easymotion-dim"})
 
     @classmethod
     def from_tmux(cls) -> "Config":
@@ -149,9 +152,12 @@ class AnsiSequence(Screen):
     HIDE_CURSOR = f"{ESC}[?25l"
     SHOW_CURSOR = f"{ESC}[?25h"
     RESET = f"{ESC}[0m"
-    DIM = f"{ESC}[2m"
-    RED = f"{ESC}[1;31m"
-    GREEN = f"{ESC}[1;32m"
+
+    def __init__(self, config: Optional["Config"] = None):
+        config = config or Config()
+        self.DIM = f"{self.ESC}[{config.dim}m"
+        self.HINT1 = f"{self.ESC}[{config.hint1_fg}m"
+        self.HINT2 = f"{self.ESC}[{config.hint2_fg}m"
 
     def init(self):
         sys.stdout.write(self.HIDE_CURSOR)
@@ -166,9 +172,9 @@ class AnsiSequence(Screen):
         if attr == self.A_DIM:
             return self.DIM
         elif attr == self.A_HINT1:
-            return self.RED
+            return self.HINT1
         elif attr == self.A_HINT2:
-            return self.GREEN
+            return self.HINT2
         return ""
 
     def addstr(self, y: int, x: int, text: str, attr=0):
@@ -185,16 +191,73 @@ class AnsiSequence(Screen):
         sys.stdout.write(self.CLEAR)
 
 
+_SGR_BASE_COLORS = {
+    30: curses.COLOR_BLACK,
+    31: curses.COLOR_RED,
+    32: curses.COLOR_GREEN,
+    33: curses.COLOR_YELLOW,
+    34: curses.COLOR_BLUE,
+    35: curses.COLOR_MAGENTA,
+    36: curses.COLOR_CYAN,
+    37: curses.COLOR_WHITE,
+}
+
+
+def _sgr_to_curses(codes: str):
+    """Parse an SGR code string (e.g. "1;31" or "38;5;208") into a
+    (foreground_color, attribute_flags) tuple for curses. Returns -1 for the
+    foreground when no color is specified (keeps the terminal default).
+
+    The curses backend supports a subset of SGR: bold (1), dim (2), the basic
+    (30-37) and bright (90-97) foregrounds, and 256-color foregrounds
+    (38;5;N). Truecolor (38;2;r;g;b) and background codes are ignored; the
+    default ANSI backend honors any SGR string."""
+    fg = -1
+    attr = 0
+    parts = [p for p in codes.split(";") if p != ""]
+    i = 0
+    while i < len(parts):
+        try:
+            n = int(parts[i])
+        except ValueError:
+            i += 1
+            continue
+        if n == 1:
+            attr |= curses.A_BOLD
+        elif n == 2:
+            attr |= curses.A_DIM
+        elif n in _SGR_BASE_COLORS:
+            fg = _SGR_BASE_COLORS[n]
+        elif 90 <= n <= 97:
+            fg = _SGR_BASE_COLORS[n - 60]
+            attr |= curses.A_BOLD
+        elif n == 38 and i + 2 < len(parts) and parts[i + 1] == "5":
+            try:
+                fg = int(parts[i + 2])
+            except ValueError:
+                pass
+            i += 2
+        i += 1
+    return fg, attr
+
+
 class Curses(Screen):
-    def __init__(self):
+    def __init__(self, config: Optional["Config"] = None):
         self.stdscr: Optional[curses.window] = None
+        self.config = config or Config()
 
     def init(self):
         self.stdscr = curses.initscr()
         curses.start_color()
         curses.use_default_colors()
-        curses.init_pair(1, curses.COLOR_RED, -1)
-        curses.init_pair(2, curses.COLOR_GREEN, -1)
+        fg1, flags1 = _sgr_to_curses(self.config.hint1_fg)
+        fg2, flags2 = _sgr_to_curses(self.config.hint2_fg)
+        _, flagsd = _sgr_to_curses(self.config.dim)
+        curses.init_pair(1, fg1, -1)
+        curses.init_pair(2, fg2, -1)
+        self.attr_hint1 = curses.color_pair(1) | flags1
+        self.attr_hint2 = curses.color_pair(2) | flags2
+        self.attr_dim = flagsd
         curses.noecho()
         curses.cbreak()
         self.stdscr.keypad(True)
@@ -209,11 +272,11 @@ class Curses(Screen):
 
     def transform_attr(self, attr):
         if attr == self.A_DIM:
-            return curses.A_DIM
+            return self.attr_dim
         elif attr == self.A_HINT1:
-            return curses.color_pair(1) | curses.A_BOLD
+            return self.attr_hint1
         elif attr == self.A_HINT2:
-            return curses.color_pair(2) | curses.A_BOLD
+            return self.attr_hint2
         return curses.A_NORMAL
 
     def addstr(self, y: int, x: int, text: str, attr=0):
@@ -985,7 +1048,7 @@ def main(screen: Screen, config: Config):
 
 if __name__ == "__main__":
     config = Config.from_tmux()
-    screen: Screen = Curses() if config.use_curses else AnsiSequence()
+    screen: Screen = Curses(config) if config.use_curses else AnsiSequence(config)
     screen.init()
     try:
         main(screen, config)

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -1416,6 +1416,9 @@ def test_config_from_tmux(tmux_server):
     set_option("@easymotion-vertical-border", "|")
     set_option("@easymotion-horizontal-border", "-")
     set_option("@easymotion-use-curses", "true")
+    set_option("@easymotion-hint1-fg", "1;34")
+    set_option("@easymotion-hint2-fg", "38;5;208")
+    set_option("@easymotion-dim", "2;90")
 
     original_run = subprocess.run
 
@@ -1435,6 +1438,9 @@ def test_config_from_tmux(tmux_server):
     assert config.vertical_border == "|"
     assert config.horizontal_border == "-"
     assert config.use_curses is True
+    assert config.hint1_fg == "1;34"
+    assert config.hint2_fg == "38;5;208"
+    assert config.dim == "2;90"
 
     # Now test with false values
     _get_all_tmux_options.cache_clear()
@@ -1516,3 +1522,33 @@ def test_get_tmux_option_with_quotes(tmux_server):
         result = get_tmux_option("@easymotion-test-quotes", "default")
 
     assert result == test_value, f"Expected '{test_value}', got '{result}'"
+
+
+def test_ansi_sequence_custom_colors():
+    """AnsiSequence builds escape sequences from configured SGR codes."""
+    config = Config(hint1_fg="1;34", hint2_fg="38;5;208", dim="2;90")
+    screen = easymotion.AnsiSequence(config)
+    assert screen.HINT1 == "\033[1;34m"
+    assert screen.HINT2 == "\033[38;5;208m"
+    assert screen.DIM == "\033[2;90m"
+
+
+def test_ansi_sequence_default_colors():
+    """AnsiSequence falls back to the default palette without config."""
+    screen = easymotion.AnsiSequence()
+    assert screen.HINT1 == "\033[1;31m"
+    assert screen.HINT2 == "\033[1;32m"
+    assert screen.DIM == "\033[2m"
+
+
+def test_sgr_to_curses_parser():
+    """_sgr_to_curses maps SGR codes to (foreground, attribute) pairs."""
+    import curses
+
+    assert easymotion._sgr_to_curses("1;31") == (curses.COLOR_RED, curses.A_BOLD)
+    assert easymotion._sgr_to_curses("38;5;208") == (208, 0)
+    assert easymotion._sgr_to_curses("2") == (-1, curses.A_DIM)
+    # bright color (90-97) implies bold
+    fg, attr = easymotion._sgr_to_curses("90")
+    assert fg == curses.COLOR_BLACK
+    assert attr & curses.A_BOLD

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -1548,6 +1548,12 @@ def test_sgr_to_curses_parser():
     assert easymotion._sgr_to_curses("1;31") == (curses.COLOR_RED, curses.A_BOLD)
     assert easymotion._sgr_to_curses("38;5;208") == (208, 0)
     assert easymotion._sgr_to_curses("2") == (-1, curses.A_DIM)
+    assert easymotion._sgr_to_curses("4;34") == (curses.COLOR_BLUE, curses.A_UNDERLINE)
+    assert easymotion._sgr_to_curses("2;90") == (
+        curses.COLOR_BLACK,
+        curses.A_DIM | curses.A_BOLD,
+    )
+    assert easymotion._sgr_to_curses("38;2;255;128;0") == (-1, 0)
     # bright color (90-97) implies bold
     fg, attr = easymotion._sgr_to_curses("90")
     assert fg == curses.COLOR_BLACK


### PR DESCRIPTION
## Summary

Closes #30 — adds the ability to customize hint colors, which were previously hardcoded to bold red / bold green.

Three new tmux options accept standard SGR color codes:

| Option | Default | Controls |
|---|---|---|
| `@easymotion-hint1-fg` | `1;31` | First hint character |
| `@easymotion-hint2-fg` | `1;32` | Second hint character |
| `@easymotion-dim` | `2` | Dimmed background text |

Example:
```bash
set -g @easymotion-hint1-fg '1;38;5;208'  # bold orange
set -g @easymotion-hint2-fg '1;38;5;33'   # bold blue
set -g @easymotion-dim '2;90'             # dim grey
```

## Implementation

- `Config` gains `hint1_fg` / `hint2_fg` / `dim` fields, auto-loaded through the existing `from_tmux()` machinery.
- The default **ANSI** backend interpolates the SGR codes straight into escape sequences — full flexibility (basic, bright, and 256-color).
- The **curses** backend translates codes via a new `_sgr_to_curses()` helper (bold/dim + basic `30-37`, bright `90-97`, and 256-color `38;5;N` foregrounds). Truecolor and background codes are ignored by curses and documented as such.

Defaults are unchanged, so existing users see no difference.

## Tests

- Extended the `Config.from_tmux()` integration test to cover the new options.
- Added unit tests for the ANSI backend (custom + default colors) and the `_sgr_to_curses` parser.
- All 65 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)