### PR TITLE
perf: batch all startup tmux queries into a single invocation

### DIFF
--- a/easymotion.py
+++ b/easymotion.py
@@ -588,14 +588,27 @@ class StartupInfo:
     window_id: str
 
 
-def get_startup_info() -> StartupInfo:
+def get_startup_info() -> Optional[StartupInfo]:
     """Fetch everything easymotion needs at startup in ONE tmux invocation:
     version, client size, window id, global options, and pane geometry.
 
     Side effects: primes the tmux-options cache and the version-dependent
     tab behaviour, replacing the separate 'tmux -V' / 'show-options -g' /
     'display-message' / 'list-panes' subprocess calls.
+
+    The batch is all-or-nothing: one failing sub-command (e.g. no client
+    for display-message) or an unparsable section kills the whole call,
+    so failure returns None and callers fall back to the lazy per-call
+    queries.
     """
+    try:
+        return _fetch_startup_info()
+    except Exception:
+        logging.error("Batched startup query failed", exc_info=True)
+        return None
+
+
+def _fetch_startup_info() -> StartupInfo:
     global _tmux_options
     out = sh_tmux_batch(
         [

--- a/easymotion.py
+++ b/easymotion.py
@@ -15,23 +15,18 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field, fields
 from typing import Any, List, Optional
 
+_SCRIPT_START = time.perf_counter()
 
-def _detect_tmux_version() -> tuple:
-    """Detect installed tmux version as (major, minor).
 
-    Returns (0, 0) when detection fails or the version cannot be parsed
-    (e.g. ``tmux master``, ``tmux openbsd-6.6``). The fallback selects the
-    pre-3.6 fixed-width tab behaviour, which matches every released tmux
-    that shipped before position-aware tab rendering.
+def _parse_tmux_version(version_str: str) -> tuple:
+    """Parse a tmux version string (``tmux 3.6a`` or bare ``3.6a``) into
+    (major, minor).
+
+    Returns (0, 0) when the version cannot be parsed (e.g. ``tmux master``,
+    ``tmux openbsd-6.6``). The fallback selects the pre-3.6 fixed-width tab
+    behaviour, which matches every released tmux that shipped before
+    position-aware tab rendering.
     """
-    try:
-        result = subprocess.run(
-            ["tmux", "-V"], capture_output=True, text=True, check=True
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return (0, 0)
-
-    version_str = result.stdout.strip()
     if "openbsd-" in version_str or "master" in version_str:
         return (0, 0)
 
@@ -41,30 +36,75 @@ def _detect_tmux_version() -> tuple:
     return (0, 0)
 
 
-TMUX_VERSION = _detect_tmux_version()
-# tmux 3.6 changed tab rendering to be position-aware (terminal-correct),
-# matching the tab-stop behaviour expected by terminals. Older tmux
-# rendered tabs as a fixed 8-column glyph regardless of column.
-_TMUX_HAS_POSITION_AWARE_TABS = TMUX_VERSION >= (3, 6)
-
-
-@functools.lru_cache(maxsize=1)
-def _get_all_tmux_options() -> dict:
-    """Batch read all tmux options in one subprocess call."""
+def _detect_tmux_version() -> tuple:
+    """Detect installed tmux version as (major, minor) via ``tmux -V``."""
     try:
         result = subprocess.run(
-            ["tmux", "show-options", "-g"], capture_output=True, text=True, check=False
+            ["tmux", "-V"], capture_output=True, text=True, check=True
         )
-        options = {}
-        for line in result.stdout.strip().split("\n"):
-            if " " in line:
-                key, value = line.split(" ", 1)
-                # Strip outer quotes and unescape inner quotes
-                value = value.strip('"').replace('\\"', '"')
-                options[key] = value
-        return options
-    except Exception:
-        return {}
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return (0, 0)
+    return _parse_tmux_version(result.stdout.strip())
+
+
+# Primed by set_tmux_version() (from the batched startup query's
+# '#{version}') or lazily via 'tmux -V' on first tab-width lookup.
+TMUX_VERSION: Optional[tuple] = None
+
+
+def set_tmux_version(version_str: str) -> None:
+    """Prime version-dependent behaviour from a version string."""
+    global TMUX_VERSION
+    TMUX_VERSION = _parse_tmux_version(version_str)
+
+
+def _position_aware_tabs() -> bool:
+    # tmux 3.6 changed tab rendering to be position-aware (terminal-correct),
+    # matching the tab-stop behaviour expected by terminals. Older tmux
+    # rendered tabs as a fixed 8-column glyph regardless of column.
+    global TMUX_VERSION
+    if TMUX_VERSION is None:
+        TMUX_VERSION = _detect_tmux_version()
+    return TMUX_VERSION >= (3, 6)
+
+
+def _parse_option_lines(lines) -> dict:
+    """Parse ``show-options -g`` output lines into a dict."""
+    options = {}
+    for line in lines:
+        if " " in line:
+            key, value = line.split(" ", 1)
+            # Strip outer quotes and unescape inner quotes
+            value = value.strip('"').replace('\\"', '"')
+            options[key] = value
+    return options
+
+
+# Single options cache: primed by get_startup_info(), or filled lazily by
+# _get_all_tmux_options() on first read.
+_tmux_options: Optional[dict] = None
+
+
+def _clear_options_cache() -> None:
+    global _tmux_options
+    _tmux_options = None
+
+
+def _get_all_tmux_options() -> dict:
+    """All global tmux options, fetched once (unless primed at startup)."""
+    global _tmux_options
+    if _tmux_options is None:
+        try:
+            result = subprocess.run(
+                ["tmux", "show-options", "-g"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            _tmux_options = _parse_option_lines(result.stdout.strip().split("\n"))
+        except Exception:
+            return {}
+    return _tmux_options
 
 
 def get_tmux_option(option: str, default: str) -> str:
@@ -373,7 +413,7 @@ def get_char_width(char: str, position: int = 0) -> int:
     pane-local 8-col tab stop.
     """
     if char == "\t":
-        if _TMUX_HAS_POSITION_AWARE_TABS:
+        if _position_aware_tabs():
             return calculate_tab_width(position)
         return 8
     return _char_width_no_tab(char)
@@ -467,20 +507,23 @@ def sh_tmux_batch(cmds: list) -> str:
     return sh(argv)
 
 
+_PANE_FORMAT = (
+    "#{pane_id},#{window_zoomed_flag},#{pane_active},"
+    "#{pane_top},#{pane_height},#{pane_left},#{pane_width},"
+    "#{pane_in_mode},#{scroll_position},"
+    "#{cursor_y},#{cursor_x},#{copy_cursor_y},#{copy_cursor_x}"
+)
+
+
 def get_initial_tmux_info():
     """Get all needed tmux info in one optimized call"""
-    format_str = (
-        "#{pane_id},#{window_zoomed_flag},#{pane_active},"
-        + "#{pane_top},#{pane_height},#{pane_left},#{pane_width},"
-        + "#{pane_in_mode},#{scroll_position},"
-        + "#{cursor_y},#{cursor_x},#{copy_cursor_y},#{copy_cursor_x}"
-    )
+    output = sh(["tmux", "list-panes", "-F", _PANE_FORMAT]).strip()
+    return _parse_pane_lines(output.split("\n"))
 
-    cmd = ["tmux", "list-panes", "-F", format_str]
-    output = sh(cmd).strip()
 
+def _parse_pane_lines(lines) -> list:
     panes_info = []
-    for line in output.split("\n"):
+    for line in lines:
         if not line:
             continue
 
@@ -532,6 +575,54 @@ def get_initial_tmux_info():
     return panes_info
 
 
+# Separator line between variable-length sections of the batched startup
+# query. Must not contain '%' (display-message expands format sequences)
+# and only collides if a tmux option value equals it exactly.
+_STARTUP_SEP = "EASYMOTION_SEP_e5a1"
+
+
+@dataclass
+class StartupInfo:
+    panes_info: Optional[list]
+    terminal_size: Optional[tuple]  # (width, height-1), None if no client
+    window_id: str
+
+
+def get_startup_info() -> StartupInfo:
+    """Fetch everything easymotion needs at startup in ONE tmux invocation:
+    version, client size, window id, global options, and pane geometry.
+
+    Side effects: primes the tmux-options cache and the version-dependent
+    tab behaviour, replacing the separate 'tmux -V' / 'show-options -g' /
+    'display-message' / 'list-panes' subprocess calls.
+    """
+    global _tmux_options
+    out = sh_tmux_batch(
+        [
+            ["display-message", "-p", "#{version},#{client_width},#{client_height}"],
+            _window_id_cmd(),
+            ["show-options", "-g"],
+            ["display-message", "-p", _STARTUP_SEP],
+            ["list-panes", "-F", _PANE_FORMAT],
+        ]
+    )
+    lines = out.split("\n")
+    version_str, client_w, client_h = lines[0].split(",")
+    window_id = lines[1].strip()
+    sep_idx = lines.index(_STARTUP_SEP, 2)
+
+    set_tmux_version(version_str)
+    _tmux_options = _parse_option_lines(lines[2:sep_idx])
+
+    try:
+        terminal_size = (int(client_w), int(client_h) - 1)
+    except ValueError:  # no attached client (e.g. detached test server)
+        terminal_size = None
+
+    panes_info = _parse_pane_lines([ln for ln in lines[sep_idx + 1 :] if ln])
+    return StartupInfo(panes_info, terminal_size, window_id)
+
+
 class PaneInfo:
     __slots__ = (
         "pane_id",
@@ -570,14 +661,19 @@ def get_terminal_size():
     return width, height - 1  # Subtract 1 from height
 
 
-def get_current_window_id():
-    """Return the window_id for the pane running this script"""
+def _window_id_cmd() -> list:
+    """display-message argv (sans 'tmux') querying this script's window_id."""
+    cmd = ["display-message", "-p"]
     pane_target = os.environ.get("TMUX_PANE")
-    cmd = ["tmux", "display-message", "-p"]
     if pane_target:
         cmd.extend(["-t", pane_target])
     cmd.append("#{window_id}")
-    return sh(cmd).strip()
+    return cmd
+
+
+def get_current_window_id():
+    """Return the window_id for the pane running this script"""
+    return sh(["tmux", *_window_id_cmd()]).strip()
 
 
 def getch(input_str=None, num_chars=1):
@@ -723,13 +819,13 @@ def generate_hints(keys: str, needed_count: Optional[int] = None) -> List[str]:
 
 
 @perf_timer()
-def init_panes():
+def init_panes(panes_info=None):
     """Initialize pane information with optimized info gathering"""
     panes = []
     max_x = 0
 
-    # Batch get all pane info
-    panes_info = get_initial_tmux_info()
+    if panes_info is None:
+        panes_info = get_initial_tmux_info()
 
     # Optimize pane processing with list comprehension
     for pane in panes_info:
@@ -964,9 +1060,15 @@ def draw_all_hints(positions, terminal_height, screen):
 
 
 @perf_timer("Total execution")
-def main(screen: Screen, config: Config):
+def main(screen: Screen, config: Config, startup: Optional[StartupInfo] = None):
     setup_logging(config.use_curses)
-    panes, max_x = init_panes()
+    logging.info(
+        f"Pre-main (interpreter+imports+startup query) took: "
+        f"{time.perf_counter() - _SCRIPT_START:.3f} seconds"
+    )
+    # Null-object so every fallback below reads uniformly.
+    startup = startup or StartupInfo(None, None, "")
+    panes, max_x = init_panes(startup.panes_info)
 
     # Get motion type from command line argument
     motion_type = sys.argv[1] if len(sys.argv) > 1 else "s"
@@ -1044,7 +1146,7 @@ def main(screen: Screen, config: Config):
                     )
                 )
 
-    terminal_width, terminal_height = get_terminal_size()
+    terminal_width, terminal_height = startup.terminal_size or get_terminal_size()
     draw_all_panes(
         panes,
         max_x,
@@ -1054,7 +1156,7 @@ def main(screen: Screen, config: Config):
         config.horizontal_border,
     )
     draw_all_hints(positions, terminal_height, screen)
-    overlay_window_id = get_current_window_id()
+    overlay_window_id = startup.window_id or get_current_window_id()
     sh(["tmux", "select-window", "-t", overlay_window_id])
 
     # Handle user input
@@ -1080,11 +1182,12 @@ def main(screen: Screen, config: Config):
 
 
 if __name__ == "__main__":
+    startup = get_startup_info()  # primes options cache + tmux version
     config = Config.from_tmux()
     screen: Screen = Curses(config) if config.use_curses else AnsiSequence(config)
     try:
         screen.init()
-        main(screen, config)
+        main(screen, config, startup)
     except KeyboardInterrupt:
         logging.info("Operation cancelled by user")
     except Exception as e:

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -11,7 +11,7 @@ from easymotion import (
     PaneInfo,
     _detect_tmux_version,
     _expand_tabs,
-    _get_all_tmux_options,
+    _clear_options_cache,
     assign_hints_by_distance,
     calculate_tab_width,
     find_matches,
@@ -20,6 +20,7 @@ from easymotion import (
     get_char_width,
     get_string_width,
     get_tmux_option,
+    get_startup_info,
     get_true_position,
     tmux_move_cursor,
     update_hints_display,
@@ -60,15 +61,11 @@ def test_get_true_position():
 def tmux_mode(request, monkeypatch):
     """Force easymotion to behave as the parametrized tmux version.
 
-    Patches both ``TMUX_VERSION`` and the cached
-    ``_TMUX_HAS_POSITION_AWARE_TABS`` flag, then clears the width caches so
-    pre-fixture lookups don't bleed into the test.
+    Patches ``TMUX_VERSION`` and clears the width caches so pre-fixture
+    lookups don't bleed into the test.
     """
     version = request.param
     monkeypatch.setattr(easymotion, "TMUX_VERSION", version)
-    monkeypatch.setattr(
-        easymotion, "_TMUX_HAS_POSITION_AWARE_TABS", version >= (3, 6)
-    )
     easymotion._char_width_no_tab.cache_clear()
     easymotion.get_string_width.cache_clear()
     yield version
@@ -1338,7 +1335,7 @@ def test_cross_pane_jump(tmux_server):
 def test_get_tmux_option_reads_value(tmux_server):
     """Integration test: verify get_tmux_option reads tmux options correctly."""
     # Clear cache to ensure fresh read
-    _get_all_tmux_options.cache_clear()
+    _clear_options_cache()
 
     # Set a custom tmux option
     test_value = f"test_hints_{uuid.uuid4().hex[:8]}"
@@ -1375,7 +1372,7 @@ def test_get_tmux_option_reads_value(tmux_server):
 def test_get_tmux_option_returns_default(tmux_server):
     """Integration test: verify get_tmux_option returns default when option not set."""
     # Clear cache to ensure fresh read
-    _get_all_tmux_options.cache_clear()
+    _clear_options_cache()
 
     # Use an option name that definitely doesn't exist
     nonexistent_option = f"@easymotion-nonexistent-{uuid.uuid4().hex}"
@@ -1399,9 +1396,41 @@ def test_get_tmux_option_returns_default(tmux_server):
 
 
 @requires_tmux
+def test_get_startup_info(tmux_server):
+    """Integration test: the single batched startup query must yield the
+    same options, panes, window id and version as the individual calls."""
+    subprocess.run(
+        ["tmux", "-L", tmux_server.server_name,
+         "set-option", "-g", "@easymotion-hints", "xyz"],
+        check=True,
+    )
+    _clear_options_cache()
+    try:
+        # TMUX_PANE from the developer's own tmux session would point at a
+        # pane that doesn't exist on the isolated test server
+        with patch("easymotion.sh", tmux_server.make_sh_for_server()), \
+                patch.dict("os.environ", {"TMUX_PANE": ""}):
+            info = get_startup_info()
+
+        assert [p.pane_id for p in info.panes_info] == [tmux_server.pane_id]
+        pane = info.panes_info[0]
+        assert pane.active and pane.width == tmux_server.width
+        assert info.window_id.startswith("@")
+        # detached test server has no attached client
+        assert info.terminal_size is None
+        # options were primed from the batch — no extra subprocess needed
+        assert get_tmux_option("@easymotion-hints", "") == "xyz"
+        assert easymotion.TMUX_VERSION is not None
+        assert easymotion.TMUX_VERSION >= (0, 0)
+    finally:
+        _clear_options_cache()
+        easymotion.TMUX_VERSION = None
+
+
+@requires_tmux
 def test_config_from_tmux(tmux_server):
     """Integration test: verify Config.from_tmux() reads all options correctly."""
-    _get_all_tmux_options.cache_clear()
+    _clear_options_cache()
 
     def set_option(name, value):
         subprocess.run(
@@ -1443,7 +1472,7 @@ def test_config_from_tmux(tmux_server):
     assert config.dim == "2;90"
 
     # Now test with false values
-    _get_all_tmux_options.cache_clear()
+    _clear_options_cache()
     set_option("@easymotion-case-sensitive", "false")
     set_option("@easymotion-smartsign", "false")
     set_option("@easymotion-use-curses", "false")
@@ -1459,7 +1488,7 @@ def test_config_from_tmux(tmux_server):
 @requires_tmux
 def test_get_tmux_option_with_spaces(tmux_server):
     """Integration test: verify option values with spaces are parsed correctly."""
-    _get_all_tmux_options.cache_clear()
+    _clear_options_cache()
 
     # Set option with spaces
     test_value = "hello world test"
@@ -1493,7 +1522,7 @@ def test_get_tmux_option_with_spaces(tmux_server):
 @requires_tmux
 def test_get_tmux_option_with_quotes(tmux_server):
     """Integration test: verify option values with quotes are parsed correctly."""
-    _get_all_tmux_options.cache_clear()
+    _clear_options_cache()
 
     # Set option with quotes (tmux stores this with escaped quotes)
     test_value = 'it"s a test'

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -1412,6 +1412,7 @@ def test_get_startup_info(tmux_server):
                 patch.dict("os.environ", {"TMUX_PANE": ""}):
             info = get_startup_info()
 
+        assert info is not None
         assert info.panes_info is not None
         assert [p.pane_id for p in info.panes_info] == [tmux_server.pane_id]
         pane = info.panes_info[0]
@@ -1426,6 +1427,17 @@ def test_get_startup_info(tmux_server):
     finally:
         _clear_options_cache()
         easymotion.TMUX_VERSION = None
+
+
+def test_get_startup_info_failure_returns_none():
+    """A failing batch (e.g. no tmux/client) must degrade to None so main
+    falls back to the lazy per-call queries instead of crashing."""
+
+    def boom(cmd):
+        raise subprocess.CalledProcessError(1, cmd)
+
+    with patch("easymotion.sh", boom):
+        assert get_startup_info() is None
 
 
 @requires_tmux

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -1412,6 +1412,7 @@ def test_get_startup_info(tmux_server):
                 patch.dict("os.environ", {"TMUX_PANE": ""}):
             info = get_startup_info()
 
+        assert info.panes_info is not None
         assert [p.pane_id for p in info.panes_info] == [tmux_server.pane_id]
         pane = info.panes_info[0]
         assert pane.active and pane.width == tmux_server.width


### PR DESCRIPTION
## Summary
Follow-up to #33: startup previously made 5 separate tmux subprocess calls (`tmux -V` at import, `show-options -g`, `list-panes`, and two `display-message` calls for client size / window id). A new `get_startup_info()` collapses them into ONE batched invocation via `sh_tmux_batch`, using a sentinel line (`%`-free — display-message expands format sequences) to separate variable-length sections.

- Version detection moves from import time into the batch, with a lazy `tmux -V` fallback so importing the module (tests, library use) still works.
- The global-options cache is primed from the same output; `get_tmux_option` interface unchanged. Simplified to a single module-level cache (was lru_cache + peek global).
- `main` consumes the batched pane list / terminal size / window id, falling back to the individual calls when info is missing (e.g. detached server without a client).
- Adds a `Pre-main (interpreter+imports+startup query) took` line to the `@easymotion-perf` log — this phase was previously unobservable.

## Benchmarks
End-to-end startup (isolated `tmux -L` server, `new-window` → single-match auto-jump → exit, median of 20):

| | before | after |
|---|---|---|
| startup end-to-end | 62.0 ms | 54.4 ms (−12%) |

The single-match path only exercised 3 of the 5 merged calls; the interactive multi-match path additionally saves the two `display-message` calls.

## Verification
- 66 tests green, including a new `test_get_startup_info` integration test (isolated server: pane geometry, window id, options priming, version).
- find_matches / tmux_move_cursor benchmarks show no regression; match snapshots identical; cursor landing verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)