### PR TITLE
fix: perf/debug logging silently broken by pre-setup logging call

### DIFF
--- a/easymotion.py
+++ b/easymotion.py
@@ -608,6 +608,11 @@ def get_startup_info() -> Optional[StartupInfo]:
     try:
         return _fetch_startup_info()
     except Exception:
+        # Logging isn't configured this early in the happy path (options
+        # come from this very query); set it up now so the failure lands
+        # in the log file instead of stderr. The lazy option fetch inside
+        # setup_logging still works when only parsing failed.
+        setup_logging()
         logging.error("Batched startup query failed", exc_info=True)
         return None
 

--- a/easymotion.py
+++ b/easymotion.py
@@ -366,10 +366,14 @@ def setup_logging(use_curses: bool = False):
         return
 
     log_file = os.path.expanduser("~/easymotion.log")
+    # force=True: any logging call made before this point (e.g. sh() debug
+    # logging inside the batched startup query) auto-installs a stderr
+    # handler, which would turn this basicConfig into a silent no-op.
     logging.basicConfig(
         filename=log_file,
         level=logging.DEBUG,
         format=f"%(asctime)s - %(levelname)s - {'CURSE' if use_curses else 'ANSI'} - %(message)s",
+        force=True,
     )
 
 
@@ -1076,7 +1080,7 @@ def draw_all_hints(positions, terminal_height, screen):
 def main(screen: Screen, config: Config, startup: Optional[StartupInfo] = None):
     setup_logging(config.use_curses)
     logging.info(
-        f"Pre-main (interpreter+imports+startup query) took: "
+        f"Pre-main (startup query + config) took: "
         f"{time.perf_counter() - _SCRIPT_START:.3f} seconds"
     )
     # Null-object so every fallback below reads uniformly.

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -1429,6 +1429,34 @@ def test_get_startup_info(tmux_server):
         easymotion.TMUX_VERSION = None
 
 
+def test_setup_logging_survives_early_logging_call(tmp_path, monkeypatch):
+    """Regression: a logging call before setup_logging (e.g. sh() debug
+    logging inside the batched startup query) auto-installs a stderr
+    handler; without force=True the later basicConfig(filename=...) is a
+    silent no-op and the perf/debug log is never written."""
+    import logging
+
+    log_file = tmp_path / "easymotion.log"
+    monkeypatch.setattr(
+        "os.path.expanduser", lambda p: str(log_file) if p.startswith("~") else p
+    )
+    monkeypatch.setattr(easymotion, "_tmux_options", {"@easymotion-perf": "true"})
+    root = logging.getLogger()
+    saved_handlers, root.handlers = root.handlers, []
+    saved_disabled = root.disabled
+    try:
+        logging.debug("early call before setup_logging")  # installs stderr handler
+        easymotion.setup_logging()
+        logging.info("after setup_logging")
+        logging.shutdown()
+        assert log_file.exists() and "after setup_logging" in log_file.read_text()
+    finally:
+        for h in root.handlers:
+            h.close()
+        root.handlers = saved_handlers
+        root.disabled = saved_disabled
+
+
 def test_get_startup_info_failure_returns_none():
     """A failing batch (e.g. no tmux/client) must degrade to None so main
     falls back to the lazy per-call queries instead of crashing."""

--- a/test_easymotion.py
+++ b/test_easymotion.py
@@ -1457,15 +1457,34 @@ def test_setup_logging_survives_early_logging_call(tmp_path, monkeypatch):
         root.disabled = saved_disabled
 
 
-def test_get_startup_info_failure_returns_none():
+def test_get_startup_info_failure_returns_none(tmp_path, monkeypatch):
     """A failing batch (e.g. no tmux/client) must degrade to None so main
-    falls back to the lazy per-call queries instead of crashing."""
+    falls back to the lazy per-call queries instead of crashing — and the
+    failure must land in the debug log file, not stderr."""
+    import logging
+
+    log_file = tmp_path / "easymotion.log"
+    monkeypatch.setattr(
+        "os.path.expanduser", lambda p: str(log_file) if p.startswith("~") else p
+    )
+    monkeypatch.setattr(easymotion, "_tmux_options", {"@easymotion-debug": "true"})
+    root = logging.getLogger()
+    saved_handlers, root.handlers = root.handlers, []
+    saved_disabled = root.disabled
 
     def boom(cmd):
         raise subprocess.CalledProcessError(1, cmd)
 
-    with patch("easymotion.sh", boom):
-        assert get_startup_info() is None
+    try:
+        with patch("easymotion.sh", boom):
+            assert get_startup_info() is None
+        logging.shutdown()
+        assert "Batched startup query failed" in log_file.read_text()
+    finally:
+        for h in root.handlers:
+            h.close()
+        root.handlers = saved_handlers
+        root.disabled = saved_disabled
 
 
 @requires_tmux


### PR DESCRIPTION
## Summary
Discovered while measuring pre-main time after #35 merged: with `@easymotion-perf true`, no log was written at all.

Root cause: the batched startup query (#35) runs before `setup_logging()` and logs through `sh()`. Python's module-level `logging.debug()` auto-installs a stderr handler when the root logger has none, which makes the later `basicConfig(filename=~/easymotion.log)` a silent no-op. Fixed with `force=True` (available since Python 3.8, the CI floor) and pinned with a regression test that fails without the flag.

Also corrects the pre-main log label — the timer starts after imports, so it covers the startup query + config only (~7 ms on my machine; `Total execution` adds ~11 ms after that).

## Verification
- 68 tests green; new `test_setup_logging_survives_early_logging_call` fails without `force=True`.
- End-to-end on an isolated server with `@easymotion-perf true`: the full perf log (`Pre-main`, `init_panes`, `Finding matches`, `Moving cursor`, `Total execution`) now appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)